### PR TITLE
Better blur and encoding settings

### DIFF
--- a/HoneCtrl.bat
+++ b/HoneCtrl.bat
@@ -30,7 +30,7 @@ cd C:\Hone
 Reg.exe add HKLM /F >nul 2>&1
 if %errorlevel% neq 0 start "" /wait /I /min powershell -NoProfile -Command start -verb runas "'%~s0'" && exit /b
 
-::Show Detailed BSoD 
+::Show Detailed BSoD
 Reg add "HKLM\System\CurrentControlSet\Control\CrashControl" /v "DisplayParameters" /t REG_DWORD /d "1" /f >nul 2>&1
 
 ::Blank/Color Character
@@ -46,9 +46,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -66,7 +66,7 @@ echo.
 echo %COL%[91m  WARNING:
 echo %COL%[37m  Please note that we cannot guarantee an FPS boost from applying our optimizations, every system + configuration is different.
 echo.
-echo     %COL%[33m1.%COL%[37m Everything is "use at your own risk", we are %COL%[91mNOT LIABLE%COL%[37m if you damage your system in any way 
+echo     %COL%[33m1.%COL%[37m Everything is "use at your own risk", we are %COL%[91mNOT LIABLE%COL%[37m if you damage your system in any way
 echo        (ex. not following the disclaimers carefully).
 echo.
 echo     %COL%[33m2.%COL%[37m If you don't know what a tweak is, do not use it and contact our support team to receive more assistance.
@@ -75,7 +75,7 @@ echo     %COL%[33m3.%COL%[37m Even though we have an automatic restore point fea
 echo.
 echo   For any questions and/or concerns, please join our discord: discord.gg/hone
 echo.
-echo   Please enter "I agree" without quotes to continue: 
+echo   Please enter "I agree" without quotes to continue:
 echo.
 echo.
 echo.
@@ -91,7 +91,7 @@ del /Q "C:\Users\%username%\AppData\Roaming\Microsoft\Windows\Start Menu\Program
 )
 
 :CheckForUpdates
-set local=2.55
+set local=2.56
 set localtwo=%local%
 if exist "%temp%\Updater.bat" DEL /S /Q /F "%temp%\Updater.bat" >nul 2>&1
 curl -g -L -# -o "%temp%\Updater.bat" "https://raw.githubusercontent.com/auraside/HoneCtrl/main/Files/HoneCtrlVer" >nul 2>&1
@@ -113,7 +113,7 @@ IF "%local%" gtr "%localtwo%" (
 	echo      [Y] Yes, Update
 	echo      [N] No
 	echo.
-	choice /c:YN /n /m "%DEL%                                >:"
+	%SystemRoot%\System32\choice.exe /c:YN /n /m "%DEL%                                >:"
 	set choice=!errorlevel!
 	if !choice! equ 1 (
 		curl -L -o %0 "https://github.com/auraside/HoneCtrl/releases/latest/download/HoneCtrl.Bat" >nul 2>&1
@@ -148,9 +148,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -162,7 +162,7 @@ echo.                   `.
 echo.
 echo                                        %COL%[90m HoneCtrl is a free and open-source desktop utility
 echo                                        %COL%[90m    made to improve your day-to-day productivity
-echo. 
+echo.
 echo.
 echo.
 echo.
@@ -179,15 +179,15 @@ echo.
 echo.
 echo.
 echo                                               %COL%[33m[%COL%[37m 6 %COL%[33m]%COL%[37m Advanced           %COL%[33m[%COL%[37m 7 %COL%[33m]%COL%[37m More
-echo. 
 echo.
 echo.
 echo.
 echo.
 echo.
-echo                                                            %COL%[31m[ X to close ]%COL%[37m  
 echo.
-choice /c:1234567X /n /m "%DEL%                                        Select a corresponding number to the options above > "
+echo                                                            %COL%[31m[ X to close ]%COL%[37m
+echo.
+%SystemRoot%\System32\choice.exe /c:1234567XD /n /m "%DEL%                                        Select a corresponding number to the options above > "
 set choice=%errorlevel%
 if "%choice%"=="1" set PG=TweaksPG1 & goto Tweaks
 if "%choice%"=="2" goto GameSettings
@@ -197,7 +197,7 @@ if "%choice%"=="5" call:Comingsoon
 if "%choice%"=="6" goto disclaimer2
 if "%choice%"=="7" goto More
 if "%choice%"=="8" exit /b
-if "%choice%"=="9" goto Disclaimer2
+if "%choice%"=="9" goto Dog
 goto MainMenu
 
 :Comingsoon
@@ -205,9 +205,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -223,7 +223,7 @@ echo.
 echo.
 echo.
 echo.
-echo                                  %COL%[31m This feature has not been finished yet but will be coming soon.  
+echo                                  %COL%[31m This feature has not been finished yet but will be coming soon.
 echo.
 echo.
 echo.
@@ -318,9 +318,9 @@ cls
 echo.
 echo                                                                                                                        %COL%[36mPage 1/2
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -384,9 +384,9 @@ cls
 echo.
 echo                                                                                                                        %COL%[36mPage 2/2
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -399,13 +399,13 @@ echo                                                               %COL%[1;4;34m
 echo.
 echo              %COL%[33m[%COL%[37m 1 %COL%[33m]%COL%[37m Disable Services %COL%[93mN/A           %COL%[33m[%COL%[37m 2 %COL%[33m]%COL%[37m Debloat %COL%[93mN/A                    %COL%[33m[%COL%[37m 3 %COL%[33m]%COL%[37m Disable Mitigations %MITOF%
 echo              %COL%[90mDisables services and lowers memory  %COL%[90mThis tweak will debloat your         %COL%[90mDisable protections against memory
-echo              %COL%[90mDon't use if you are using Wi-Fi     %COL%[90msystem and disable telemetry         %COL%[90mbased attacks that consume perf
+echo              %COL%[91mDon't use if you are using Wi-Fi     %COL%[90msystem and disable telemetry         %COL%[90mbased attacks that consume perf
 echo.
 echo                                                           %COL%[1;4;34mNetwork Tweaks%COL%[0m
 echo.
 echo              %COL%[33m[%COL%[37m 4 %COL%[33m]%COL%[37m Optimize TCP/IP %TCPOF%            %COL%[33m[%COL%[37m 5 %COL%[33m]%COL%[37m Optimize NIC %NICOF%               %COL%[33m[%COL%[37m 6 %COL%[33m]%COL%[37m Optimize Netsh %NETOF%
 echo              %COL%[90mTweaks your Internet Protocol        %COL%[90mOptimize your Network Card settings  %COL%[90mThis tweak will optimize your
-echo              %COL%[90mDon't use if you are using Wi-Fi     %COL%[90mDon't use if you are using Wi-Fi     %COL%[90mcomputer network configuration
+echo              %COL%[91mDon't use if you are using Wi-Fi     %COL%[91mDon't use if you are using Wi-Fi     %COL%[90mcomputer network configuration
 echo.
 echo                                                             %COL%[1;4;34mGPU ^& CPU%COL%[0m
 echo.
@@ -447,9 +447,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -462,7 +462,7 @@ rem echo                                                           %COL%[1;4;34m
 rem echo.
 rem echo              %COL%[33m[%COL%[37m 3 %COL%[33m]%COL%[37m Disable USB Power Savings %BLANK%  %COL%[33m[%COL%[37m 4 %COL%[33m]%COL%[37m CSRSS high priority %BLANK%        %COL%[33m[%COL%[37m 5 %COL%[33m]%COL%[37m Disable HPET %BLANK%
 rem echo              %COL%[90mTweaks your Internet Protocol        %COL%[90mCSRSS is for mouse input, setting    %COL%[90mCSRSS is responsible for mouse input
-rem echo              %COL%[90mDon't use if you are using Wi-Fi     %COL%[90mhigh priority may improve latency    %COL%[90mset to high to improve input latency
+rem echo              %COL%[91mDon't use if you are using Wi-Fi     %COL%[90mhigh priority may improve latency    %COL%[90mset to high to improve input latency
 echo                                                        %COL%[1;4;34mMiscellaneous Tweaks%COL%[0m
 echo.
 echo              %COL%[33m[%COL%[37m 1 %COL%[33m]%COL%[37m Cleaner %BLANK%                    %COL%[33m[%COL%[37m 2 %COL%[33m]%COL%[37m Game-Booster %BLANK%               %COL%[33m[%COL%[37m 3 %COL%[33m]%COL%[37m Soft Restart %BLANK%
@@ -473,7 +473,7 @@ echo.
 echo.                                                     	  %COL%[1;4;31mAdvanced Tweaks%COL%[0m
 echo.
 echo.			 			     %COL%[33m[%COL%[37m Press A to go to page %COL%[33m]
-echo.	
+echo.
 echo.
 echo.
 echo.
@@ -617,16 +617,29 @@ goto Advanced
 
 :TimerRes
 cd C:\Hone\Resources
+sc config "STR" start= auto >nul 2>&1
+start /b net start STR >nul 2>&1
 if "%TMROF%" equ "%COL%[91mOFF" (
 	if not exist SetTimerResolutionService.exe (
 		::https://forums.guru3d.com/threads/windows-timer-resolution-tool-in-form-of-system-service.376458/
 		curl -g -L -# -o "C:\Hone\Resources\SetTimerResolutionService.exe" "https://github.com/auraside/HoneCtrl/raw/main/Files/SetTimerResolutionService.exe" >nul 2>&1
 		%windir%\Microsoft.NET\Framework\v4.0.30319\InstallUtil.exe /i SetTimerResolutionService.exe >nul 2>&1
 	)
-	sc config "STR" start=auto >nul 2>&1
-	start /b net start STR >nul 2>&1
-	bcdedit /set useplatformtick true >nul 2>&1
-	bcdedit /set disabledynamictick yes >nul 2>&1
+		sc config "STR" start=auto >nul 2>&1
+		start /b net start STR >nul 2>&1
+		bcdedit /set disabledynamictick yes >nul 2>&1
+		bcdedit /deletevalue useplatformclock >nul 2>&1
+	for /F "tokens=2 delims==" %%G in (
+	'wmic OS get buildnumber /value'
+	) do @for /F "tokens=*" %%x in ("%%G") do (
+		set "VAR=%%~x"
+	)
+	if !VAR! geq 19042 (
+		bcdedit /deletevalue useplatformtick >nul 2>&1
+	)
+	if !VAR! lss 19042 (
+		bcdedit /set useplatformtick yes >nul 2>&1
+	)
 ) else (
 	sc config "STR" start=disabled >nul 2>&1
 	start /b net stop STR >nul 2>&1
@@ -672,7 +685,41 @@ if "%MSIOF%" equ "%COL%[91mOFF" (
 goto Tweaks
 
 :TCPIP
+Reg query "HKCU\Software\Hone" /v "WifiDisclaimer2" >nul 2>&1 && goto TCPIP2
 cls
+echo.
+echo.
+echo.                                      %COL%[33m+N.
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
+echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
+echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
+echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
+echo.                    :NMMs-oo+/syy:-     #+#    #+#    #+#   #+#+#    #+#          %COL%[37m#+#%COL%[33m    +#+   #+#     #+#   #+#
+echo.                   /NMN+ ``   :ys.      ########     ###    ####    ##########   %COL%[37m###%COL%[33m       ######        ######
+echo.                  `NMN:        +.                                                      ##    ###     ##    ###
+echo.                  om-                                                                   #######       #######
+echo.                   `.
+echo.
+echo                                        %COL%[90m HoneCtrl is a free and open-source desktop utility
+echo                                        %COL%[90m    made to improve your day-to-day productivity
+echo.
+echo.
+echo.
+echo %COL%[91m  WARNING:
+echo %COL%[91m  This tweak is for ethernet users only, if you're on Wi-Fi, do not run this tweak.
+echo.
+echo   %COL%[37mFor any questions and/or concerns, please join our discord: discord.gg/hone
+echo.
+echo   %COL%[37mPlease enter "I understand" without quotes to continue:
+echo.
+echo.
+echo.
+set /p "input=%DEL%                                                            >: %COL%[92m"
+if /i "!input!" neq "i understand" goto Tweaks
+Reg add "HKCU\Software\Hone" /v "WifiDisclaimer2" /f >nul 2>&1
+:TCPIP2
 if "%TCPOF%" equ "%COL%[91mOFF" (
 	Reg add "HKCU\Software\Hone" /v "TCPIP" /f
 	PowerShell -NoProfile -NonInteractive -Command ^
@@ -711,7 +758,7 @@ if "%TCPOF%" equ "%COL%[91mOFF" (
 		Reg add "HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\%%i" /v "TcpInitialRTT" /d "300" /t REG_DWORD /f
         Reg add "HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\%%i" /v "UseZeroBroadcast" /d "0" /t REG_DWORD /f
         Reg add "HKLM\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\%%i" /v "DeadGWDetectDefault" /d "1" /t REG_DWORD /f
-	) 
+	)
 ) >nul 2>&1 else (
 	Reg delete "HKCU\Software\Hone" /v "TCPIP" /f
 	PowerShell -NoProfile -NonInteractive -Command ^
@@ -752,6 +799,41 @@ start /B cmd /c "ipconfig /release & ipconfig /renew" >nul 2>&1
 goto Tweaks
 
 :NIC
+Reg query "HKCU\Software\Hone" /v "WifiDisclaimer4" >nul 2>&1 && goto NIC2
+cls
+echo.
+echo.
+echo.                                      %COL%[33m+N.
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
+echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
+echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
+echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
+echo.                    :NMMs-oo+/syy:-     #+#    #+#    #+#   #+#+#    #+#          %COL%[37m#+#%COL%[33m    +#+   #+#     #+#   #+#
+echo.                   /NMN+ ``   :ys.      ########     ###    ####    ##########   %COL%[37m###%COL%[33m       ######        ######
+echo.                  `NMN:        +.                                                      ##    ###     ##    ###
+echo.                  om-                                                                   #######       #######
+echo.                   `.
+echo.
+echo                                        %COL%[90m HoneCtrl is a free and open-source desktop utility
+echo                                        %COL%[90m    made to improve your day-to-day productivity
+echo.
+echo.
+echo.
+echo %COL%[91m  WARNING:
+echo %COL%[91m  This tweak is for ethernet users only, if you're on Wi-Fi, do not run this tweak.
+echo.
+echo   %COL%[37mFor any questions and/or concerns, please join our discord: discord.gg/hone
+echo.
+echo   %COL%[37mPlease enter "I understand" without quotes to continue:
+echo.
+echo.
+echo.
+set /p "input=%DEL%                                                            >: %COL%[92m"
+if /i "!input!" neq "i understand" goto Tweaks
+Reg add "HKCU\Software\Hone" /v "WifiDisclaimer4" /f >nul 2>&1
+:NIC2
 cd %SystemDrive%\Hone\HoneRevert
 if "%NICOF%" neq "%COL%[91mOFF" (
 	reg import ognic.reg >nul 2>&1
@@ -766,16 +848,16 @@ Reg add "%%g" /v "MIMOPowerSaveMode" /t REG_SZ /d "3" /f
 Reg add "%%g" /v "PowerSavingMode" /t REG_SZ /d "0" /f
 Reg add "%%g" /v "EnableGreenEthernet" /t REG_SZ /d "0" /f
 Reg add "%%g" /v "*EEE" /t REG_SZ /d "0" /f
-Reg add "%%g" /v "EnableConnectedPowerGating" /t REG_DWORD /d "0" /f
-Reg add "%%g" /v "EnableDynamicPowerGating" /t REG_SZ /d "0" /f
-Reg add "%%g" /v "EnableSavePowerNow" /t REG_SZ /d "0" /f
-Reg add "%%g" /v "PnPCapabilities" /t REG_SZ /d "24" /f
 Rem more powersaving options
-Reg add "%%g" /v "*NicAutoPowerSaver" /t REG_SZ /d "0" /f
-Reg add "%%g" /v "ULPMode" /t REG_SZ /d "0" /f
-Reg add "%%g" /v "EnablePME" /t REG_SZ /d "0" /f
-Reg add "%%g" /v "AlternateSemaphoreDelay" /t REG_SZ /d "0" /f
-Reg add "%%g" /v "AutoPowerSaveModeEnabled" /t REG_SZ /d "0" /f
+Rem Reg add "%%g" /v "EnableConnectedPowerGating" /t REG_DWORD /d "0" /f
+Rem add "%%g" /v "EnableDynamicPowerGating" /t REG_SZ /d "0" /f
+Rem Reg add "%%g" /v "EnableSavePowerNow" /t REG_SZ /d "0" /f
+Rem Reg add "%%g" /v "PnPCapabilities" /t REG_SZ /d "24" /f
+Rem Reg add "%%g" /v "*NicAutoPowerSaver" /t REG_SZ /d "0" /f
+Rem Reg add "%%g" /v "ULPMode" /t REG_SZ /d "0" /f
+Rem Reg add "%%g" /v "EnablePME" /t REG_SZ /d "0" /f
+Rem Reg add "%%g" /v "AlternateSemaphoreDelay" /t REG_SZ /d "0" /f
+Rem Reg add "%%g" /v "AutoPowerSaveModeEnabled" /t REG_SZ /d "0" /f
 
 )
 ) >nul 2>&1
@@ -790,16 +872,14 @@ if "%NETOF%" equ "%COL%[91mOFF" (
     netsh int tcp set global netdma=enabled
     netsh interface isatap set state disabled
     netsh int tcp set global timestamps=disabled
-    netsh int tcp set supplemental Internet congestionprovider=ctcp
     netsh int tcp set global rss=enabled
     netsh int tcp set global nonsackrttresiliency=disabled
     netsh int tcp set global initialRto=2000
-    netsh int udp set global uro=enabled
     netsh int tcp set supplemental template=custom icw=10
-    netsh interface teredo set state disable
-    netsh int tcp set global hystart=disabled
 
-    
+
+
+
 netsh interface ip set interface ethernet currenthoplimit=64
 ) >nul 2>&1 else (
     Reg delete "HKCU\Software\Hone" /v InternetTweaks /f
@@ -809,12 +889,9 @@ netsh interface ip set interface ethernet currenthoplimit=64
     netsh int tcp set global chimney=default
     netsh int tcp set global dca=default
     netsh int tcp set global netdma=default
-    netsh int tcp set global ecncapability=default
     netsh int tcp set global timestamps=default
     netsh int tcp set global nonsackrttresiliency=default
-    netsh int tcp set global hystart=enabled
-    netsh interface isatap set state default
-    netsh interface ip set interface ethernet currenthoplimit=128
+
 ) >nul 2>&1
 goto Tweaks
 
@@ -925,98 +1002,98 @@ goto Tweaks
 :Debloat
 if "%DEBOF%" equ "%COL%[91mOFF" (
     Reg add "HKCU\Software\Hone" /v DebloatTweaks /f
-	schtasks /Change /TN "Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser" /Disable 
-	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\WMI\AutoLogger\AutoLogger-Diagtrack-Listener" /v "Start" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\WindowsSelfHost\UI\Visibility" /v "DiagnosticErrorText" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\WindowsSelfHost\UI\Strings" /v "DiagnosticErrorText" /t REG_SZ /d "" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\WindowsSelfHost\UI\Strings" /v "DiagnosticLinkText" /t REG_SZ /d "" /f  
-	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\PhishingFilter" /v "EnabledV9" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\TabletPC" /v "PreventHandwritingDataSharing" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports" /v "PreventHandwritingErrorReports" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\AppCompat" /v "DisableInventory" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\AppCompat" /v "DisableUAR" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Personalization" /v "NoLockScreenCamera" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\AdvertisingInfo" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Input\TIPC" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\System" /v "AllowExperimentation" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Bluetooth" /v "AllowAdvertising" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\SQMClient\Windows" /v "CEIPEnable" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Messaging" /v "AllowMessageSync" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Biometrics" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\PushNotifications" /v "ToastEnabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Control Panel\International\User Profile" /v "HttpAcceptLanguageOptOut" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\AppHost" /v "EnableWebContentEvaluation" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{C1D23ACC-752B-43E5-8448-8D0E519CD6D6}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Start_TrackProgs" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowSyncProviderNotifications" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{2297E4E2-5DBE-466D-A12B-0F8286F0D9CA}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{E5323777-F976-4f5b-9B55-B94699C46E44}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{2EEF81BE-33FA-4800-9670-1CD474972C3F}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{52079E78-A92B-413F-B213-E8FE35712E72}" /v "Value" /t REG_SZ /d "Deny" /f   
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{7D7E8402-7C54-4821-A34E-AEEFD62DED93}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{D89823BA-7180-4B81-B50C-7E471E6121A3}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{8BC668CF-7728-45BD-93F8-CF2B3B41D7AB}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{9231CB4C-BF57-4AF3-8C55-FDA7BFCC04C5}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{E390DF20-07DF-446D-B962-F5C953062741}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{992AFA70-6F47-4148-B3E9-3003349C1548}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" /v "GlobalUserDisabled" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\DiagTrack" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\dmwappushservice" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\WMI\Autologger\AutoLogger-Diagtrack-Listener" /v "Start" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\WMDRM" /v "DisableOnline" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{A8804298-2D5F-42E3-9531-9C8C39EB29CE}" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\LooselyCoupled" /v "Value" /t REG_SZ /d "Deny" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\CredUI" /v "DisablePasswordReveal" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\Main" /v "DoNotTrack" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\Main" /v "OptimizeWindowsSearchResultsForScreenReaders" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\FlipAhead" /v "FPEnabled" /t REG_DWORD /d "0" /f   
-	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\User\Default\SearchScopes" /v "ShowSearchSuggestionsGlobal" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Browser" /v "AllowAddressBarDropdown" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\Privacy" /v "EnableEncryptedMediaExtensions" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync" /v "SyncPolicy" /t REG_DWORD /d "5" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Personalization" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\BrowserSettings" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Credentials" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Language" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Accessibility" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Windows" /v "Enabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "AllowCloudSearch" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "ConnectedSearchUseWeb" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "DisableWebSearch" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "AllowSearchToUseLocation" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "AllowCortana" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\Speech_OneCore\Preferences" /v "ModelDownloadAllowed" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\InputPersonalization\TrainedDataStore" /v "HarvestContacts" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\InputPersonalization" /v "RestrictImplicitTextCollection" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Microsoft\InputPersonalization" /v "RestrictImplicitInkCollection" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Personalization\Settings" /v "AcceptedPrivacyPolicy" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors" /v "DisableWindowsLocationProvider" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors" /v "DisableLocationScripting" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\Sensor\Permissions\{BFA794E4-F964-4FDB-90F6-51056BFE4B44}" /v "SensorPermissionState" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v "DoNotShowFeedbackNotifications" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization" /v "DODownloadMode" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeliveryOptimization" /v "SystemSettingsDownloadMode" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Speech" /v "AllowSpeechModelUpdate" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DeferUpgrade" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DeferUpgradePeriod" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DeferUpdatePeriod" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Device Metadata" /v "PreventDeviceMetadataFromNetwork" /t REG_DWORD /d "1" /f  	
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsStore\WindowsUpdate" /v "AutoDownload" /t REG_DWORD /d "2" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\wuauserv" /v "Start" /t REG_DWORD /d "3" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\7971f918-a847-4430-9279-4a52d1efe18d" /v "RegisteredWithAU" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Microsoft\OneDrive" /v "PreventNetworkTrafficPreUserSignIn" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet" /v "SpyNetReporting" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet" /v "SubmitSamplesConsent" /t REG_DWORD /d "2" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\MRT" /v "DontReportInfectionInformation" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender" /v "DisableAntiSpyware" /t REG_DWORD /d "1" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Siuf\Rules" /v "NumberOfSIUFInPeriod" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Siuf\Rules" /v "PeriodInNanoSeconds" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\Search" /v "BingSearchEnabled" /t REG_DWORD /d "0" /f  
-	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "SilentInstalledAppsEnabled" /t REG_DWORD /d "0" /f  
+	schtasks /Change /TN "Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser" /Disable
+	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\WMI\AutoLogger\AutoLogger-Diagtrack-Listener" /v "Start" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\WindowsSelfHost\UI\Visibility" /v "DiagnosticErrorText" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\WindowsSelfHost\UI\Strings" /v "DiagnosticErrorText" /t REG_SZ /d "" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\WindowsSelfHost\UI\Strings" /v "DiagnosticLinkText" /t REG_SZ /d "" /f
+	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\PhishingFilter" /v "EnabledV9" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\TabletPC" /v "PreventHandwritingDataSharing" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\HandwritingErrorReports" /v "PreventHandwritingErrorReports" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\AppCompat" /v "DisableInventory" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\AppCompat" /v "DisableUAR" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Personalization" /v "NoLockScreenCamera" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\AdvertisingInfo" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Input\TIPC" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\System" /v "AllowExperimentation" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Bluetooth" /v "AllowAdvertising" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\SQMClient\Windows" /v "CEIPEnable" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Messaging" /v "AllowMessageSync" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Biometrics" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\PushNotifications" /v "ToastEnabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Control Panel\International\User Profile" /v "HttpAcceptLanguageOptOut" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\AppHost" /v "EnableWebContentEvaluation" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{C1D23ACC-752B-43E5-8448-8D0E519CD6D6}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Start_TrackProgs" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowSyncProviderNotifications" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{2297E4E2-5DBE-466D-A12B-0F8286F0D9CA}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{E5323777-F976-4f5b-9B55-B94699C46E44}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{2EEF81BE-33FA-4800-9670-1CD474972C3F}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{52079E78-A92B-413F-B213-E8FE35712E72}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{7D7E8402-7C54-4821-A34E-AEEFD62DED93}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{D89823BA-7180-4B81-B50C-7E471E6121A3}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{8BC668CF-7728-45BD-93F8-CF2B3B41D7AB}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{9231CB4C-BF57-4AF3-8C55-FDA7BFCC04C5}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{E390DF20-07DF-446D-B962-F5C953062741}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{992AFA70-6F47-4148-B3E9-3003349C1548}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" /v "GlobalUserDisabled" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\DiagTrack" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\dmwappushservice" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\WMI\Autologger\AutoLogger-Diagtrack-Listener" /v "Start" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\WMDRM" /v "DisableOnline" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\{A8804298-2D5F-42E3-9531-9C8C39EB29CE}" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeviceAccess\Global\LooselyCoupled" /v "Value" /t REG_SZ /d "Deny" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\CredUI" /v "DisablePasswordReveal" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\Main" /v "DoNotTrack" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\Main" /v "OptimizeWindowsSearchResultsForScreenReaders" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\FlipAhead" /v "FPEnabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\User\Default\SearchScopes" /v "ShowSearchSuggestionsGlobal" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Browser" /v "AllowAddressBarDropdown" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\Privacy" /v "EnableEncryptedMediaExtensions" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync" /v "SyncPolicy" /t REG_DWORD /d "5" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Personalization" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\BrowserSettings" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Credentials" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Language" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Accessibility" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Windows" /v "Enabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "AllowCloudSearch" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "ConnectedSearchUseWeb" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "DisableWebSearch" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "AllowSearchToUseLocation" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Search" /v "AllowCortana" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\Speech_OneCore\Preferences" /v "ModelDownloadAllowed" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\InputPersonalization\TrainedDataStore" /v "HarvestContacts" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\InputPersonalization" /v "RestrictImplicitTextCollection" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Microsoft\InputPersonalization" /v "RestrictImplicitInkCollection" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Microsoft\Personalization\Settings" /v "AcceptedPrivacyPolicy" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors" /v "DisableWindowsLocationProvider" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors" /v "DisableLocationScripting" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\Sensor\Permissions\{BFA794E4-F964-4FDB-90F6-51056BFE4B44}" /v "SensorPermissionState" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection" /v "DoNotShowFeedbackNotifications" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" /v "AllowTelemetry" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization" /v "DODownloadMode" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\DeliveryOptimization" /v "SystemSettingsDownloadMode" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Speech" /v "AllowSpeechModelUpdate" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DeferUpgrade" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DeferUpgradePeriod" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" /v "DeferUpdatePeriod" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Device Metadata" /v "PreventDeviceMetadataFromNetwork" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsStore\WindowsUpdate" /v "AutoDownload" /t REG_DWORD /d "2" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\wuauserv" /v "Start" /t REG_DWORD /d "3" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\7971f918-a847-4430-9279-4a52d1efe18d" /v "RegisteredWithAU" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Microsoft\OneDrive" /v "PreventNetworkTrafficPreUserSignIn" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet" /v "SpyNetReporting" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet" /v "SubmitSamplesConsent" /t REG_DWORD /d "2" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\MRT" /v "DontReportInfectionInformation" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender" /v "DisableAntiSpyware" /t REG_DWORD /d "1" /f
+	Reg.exe add "HKCU\Software\Microsoft\Siuf\Rules" /v "NumberOfSIUFInPeriod" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Siuf\Rules" /v "PeriodInNanoSeconds" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\Search" /v "BingSearchEnabled" /t REG_DWORD /d "0" /f
+	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "SilentInstalledAppsEnabled" /t REG_DWORD /d "0" /f
 	Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "SoftLandingEnabled" /t REG_DWORD /d "0" /f
 )>nul 2>&1 else (
     Reg delete "HKCU\Software\Hone" /v DebloatTweaks /f
@@ -1084,7 +1161,7 @@ if "%DEBOF%" equ "%COL%[91mOFF" (
     Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Language" /v "Enabled" /t REG_DWORD /d "1" /f >nul 2>&1
     Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Accessibility" /v "Enabled" /t REG_DWORD /d "1" /f >nul 2>&1
     Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Windows" /v "Enabled" /t REG_DWORD /d "1" /f >nul 2>&1
-    Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Personalization" /v "Enabled" /t REG_DWORD /d "1" /f  
+    Reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\SettingSync\Groups\Personalization" /v "Enabled" /t REG_DWORD /d "1" /f
 ) >nul 2>&1
 goto Tweaks
 
@@ -1147,7 +1224,7 @@ if "%MOUOF%" neq "%COL%[91mOFF" (
 	Reg add "HKEY_CURRENT_USER\Control Panel\Mouse" /v "SmoothMouseYCurve" /t REG_BINARY /d "0000000000000000fd11010000000000002404000000000000fc12000000000000c0bb0100000000" /f >nul 2>&1
 	goto Tweaks
 )
-echo what is your display scaling? 
+echo what is your display scaling?
 echo go to settings , system , display , then type the scale percentage like 100, 125, 150
 set /p choice=" Scale >  "
 Reg add "HKCU\Control Panel\Mouse" /v "MouseSpeed" /t REG_SZ /d "0" /f >nul 2>&1
@@ -1197,7 +1274,7 @@ if "%NPIOF%" equ "%COL%[91mOFF" (
 	del /F /Q "C:\Hone\Resources\nvidiaProfileInspector.zip"
 	curl -g -L -# -o "C:\Hone\Resources\nvidiaProfileInspector\Latency_and_Performances_Settings_by_Hone_Team2.nip" "https://raw.githubusercontent.com/auraside/HoneCtrl/main/Files/Latency_and_Performances_Settings_by_Hone_Team2.nip"
 	cd "C:\Hone\Resources\nvidiaProfileInspector\"
-	nvidiaProfileInspector.exe "Latency_and_Performances_Settings_by_Hone_Team2.nip" 
+	nvidiaProfileInspector.exe "Latency_and_Performances_Settings_by_Hone_Team2.nip"
 ) >nul 2>&1 else (
 ::https://github.com/Orbmu2k/nvidiaProfileInspector/releases/latest/download/nvidiaProfileInspector.zip
 	Reg delete "HKCU\Software\Hone" /v NpiTweaks /f
@@ -1278,100 +1355,136 @@ Reg add "HKLM\SYSTEM\CurrentControlSet\Services\nvlddmkm" /v "DisableWriteCombin
 ) >nul 2>&1 else (
 Reg delete "HKLM\SYSTEM\CurrentControlSet\Services\nvlddmkm" /v "DisableWriteCombining" /f
 ) >nul 2>&1
+goto Tweaks
 
 :Service
+Reg query "HKCU\Software\Hone" /v "WifiDisclaimer1" >nul 2>&1 && goto Service2
+cls
+echo.
+echo.
+echo.                                      %COL%[33m+N.
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
+echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
+echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
+echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
+echo.                    :NMMs-oo+/syy:-     #+#    #+#    #+#   #+#+#    #+#          %COL%[37m#+#%COL%[33m    +#+   #+#     #+#   #+#
+echo.                   /NMN+ ``   :ys.      ########     ###    ####    ##########   %COL%[37m###%COL%[33m       ######        ######
+echo.                  `NMN:        +.                                                      ##    ###     ##    ###
+echo.                  om-                                                                   #######       #######
+echo.                   `.
+echo.
+echo                                        %COL%[90m HoneCtrl is a free and open-source desktop utility
+echo                                        %COL%[90m    made to improve your day-to-day productivity
+echo.
+echo.
+echo.
+echo %COL%[91m  WARNING:
+echo %COL%[91m  This tweak is for ethernet users only, if you're on Wi-Fi, do not run this tweak.
+echo.
+echo   %COL%[37mFor any questions and/or concerns, please join our discord: discord.gg/hone
+echo.
+echo   %COL%[37mPlease enter "I understand" without quotes to continue:
+echo.
+echo.
+echo.
+set /p "input=%DEL%                                                            >: %COL%[92m"
+if /i "!input!" neq "i understand" goto Tweaks
+Reg add "HKCU\Software\Hone" /v "WifiDisclaimer1" /f >nul 2>&1
+:Service2
 if "%SERVOF%" equ "%COL%[91mOFF" (
     Reg add "HKCU\Software\Hone" /v ServicesTweaks /f
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\xbgm" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XboxGipSvc" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WaaSMedicSvc" /v "Start" /t REG_DWORD /d "4" /f 
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time" /v "Start" /t REG_DWORD /d "4" /f  
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WaaSMedicSvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time" /v "Start" /t REG_DWORD /d "4" /f
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\spectrum" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wcncsvc" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WebClient" /v "Start" /t REG_DWORD /d "4" /f 
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WebClient" /v "Start" /t REG_DWORD /d "4" /f
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SysMain" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NcaSvc" /v "Start" /t REG_DWORD /d "4" /f  
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NcaSvc" /v "Start" /t REG_DWORD /d "4" /f
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\diagsvc" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\UserDataSvc" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\stisvc" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\AdobeFlashPlayerUpdateSvc" /v "Start" /t REG_DWORD /d "4" /f 
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TrkWks" /v "Start" /t REG_DWORD /d "4" /f 
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\dmwappushservice" /v "Start" /t REG_DWORD /d "4" /f   
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PimIndexMaintenanceSvc" /v "Start" /t REG_DWORD /d "4" /f   
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DiagTrack" /v "Start" /t REG_DWORD /d "4" /f 
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\AdobeFlashPlayerUpdateSvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TrkWks" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\dmwappushservice" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PimIndexMaintenanceSvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DiagTrack" /v "Start" /t REG_DWORD /d "4" /f
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\GoogleChromeElevationService" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\OneSyncSvc" /v "Start" /t REG_DWORD /d "4" /f 
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ibtsiva" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SNMPTRAP" /v "Start" /t REG_DWORD /d "4" /f   	
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\pla" /v "Start" /t REG_DWORD /d "4" /f 
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ssh-agent" /v "Start" /t REG_DWORD /d "4" /f   
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\sshd" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DoSvc" /v "Start" /t REG_DWORD /d "4" /f    
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WbioSrvc" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PcaSvc" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetTcpPortSharing" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wersvc" /v "Start" /t REG_DWORD /d "4" /f   
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate" /v "Start" /t REG_DWORD /d "4" /f   
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MSiSCSI" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WMPNetworkSvc" /v "Start" /t REG_DWORD /d "4" /f  
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\OneSyncSvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ibtsiva" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SNMPTRAP" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\pla" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ssh-agent" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\sshd" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DoSvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WbioSrvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PcaSvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetTcpPortSharing" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wersvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MSiSCSI" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WMPNetworkSvc" /v "Start" /t REG_DWORD /d "4" /f
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CDPUserSvc" /v "Start" /t REG_DWORD /d "4" /f >nul 2>&1
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanWorkstation" /v "Start" /t REG_DWORD /d "4" /f   
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\UnistoreSvc" /v "Start" /t REG_DWORD /d "4" /f 
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MapsBroker" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\debugregsvc" /v "Start" /t REG_DWORD /d "4" /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Ndu" /v "Start" /d "2" /t REG_DWORD /f  
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TimeBrokerSvc" /v "Start" /d "3" /t REG_DWORD /f 
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VaultSvc" /v "Start" /t REG_DWORD /d "3" /f 
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanWorkstation" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\UnistoreSvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MapsBroker" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\debugregsvc" /v "Start" /t REG_DWORD /d "4" /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Ndu" /v "Start" /d "2" /t REG_DWORD /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TimeBrokerSvc" /v "Start" /d "3" /t REG_DWORD /f
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VaultSvc" /v "Start" /t REG_DWORD /d "3" /f
 	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wuauserv" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
-	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CertPropSvc" /v "Start" /t REG_DWORD /d "3" /f   
+	Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CertPropSvc" /v "Start" /t REG_DWORD /d "3" /f
 	)>nul 2>&1 else (
-    Reg delete "HKCU\Software\Hone" /v ServicesTweaks /f   
+    Reg delete "HKCU\Software\Hone" /v ServicesTweaks /f
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\xbgm" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XboxGipSvc" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WaaSMedicSvc" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wuauserv" /v "Start" /t REG_DWORD /d "3" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time" /v "Start" /t REG_DWORD /d "3" /f  
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wuauserv" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time" /v "Start" /t REG_DWORD /d "3" /f
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\spectrum" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wcncsvc" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WebClient" /v "Start" /t REG_DWORD /d "3" /f 
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WebClient" /v "Start" /t REG_DWORD /d "3" /f
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SysMain" /v "Start" /t REG_DWORD /d "2" /f >nul 2>&1
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NcaSvc" /v "Start" /t REG_DWORD /d "3" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\AdobeFlashPlayerUpdateSvc" /v "Start" /t REG_DWORD /d "3" /f 
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NcaSvc" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\AdobeFlashPlayerUpdateSvc" /v "Start" /t REG_DWORD /d "3" /f
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\GoogleChromeElevationService" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TrkWks" /v "Start" /t REG_DWORD /d "3" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ibtsiva" /v "Start" /t REG_DWORD /d "3" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\sshd" /v "Start" /t REG_DWORD /d "3" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate" /v "Start" /t REG_DWORD /d "2" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem" /v "Start" /t REG_DWORD /d "3" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PimIndexMaintenanceSvc" /v "Start" /t REG_DWORD /d "3" /f  
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TrkWks" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ibtsiva" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\sshd" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PimIndexMaintenanceSvc" /v "Start" /t REG_DWORD /d "3" /f
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\diagsvc" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\UserDataSvc" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\stisvc" /v "Start" /t REG_DWORD /d "3" /f >nul 2>&1
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\dmwappushservice" /v "Start" /t REG_DWORD /d "3" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DiagTrack" /v "Start" /t REG_DWORD /d "2" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VaultSvc" /v "Start" /t REG_DWORD /d "3" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\OneSyncSvc" /v "Start" /t REG_DWORD /d "2" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SNMPTRAP" /v "Start" /t REG_DWORD /d "3" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\pla" /v "Start" /t REG_DWORD /d "3" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ssh-agent" /v "Start" /t REG_DWORD /d "3" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DoSvc" /v "Start" /t REG_DWORD /d "2" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CertPropSvc" /v "Start" /t REG_DWORD /d "3" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WbioSrvc" /v "Start" /t REG_DWORD /d "3" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PcaSvc" /v "Start" /t REG_DWORD /d "2" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetTcpPortSharing" /v "Start" /t REG_DWORD /d "4" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wersvc" /v "Start" /t REG_DWORD /d "3" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MSiSCSI" /v "Start" /t REG_DWORD /d "3" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WMPNetworkSvc" /v "Start" /t REG_DWORD /d "3" /f  
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\dmwappushservice" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DiagTrack" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VaultSvc" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\OneSyncSvc" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SNMPTRAP" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\pla" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ssh-agent" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\DoSvc" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CertPropSvc" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WbioSrvc" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PcaSvc" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetTcpPortSharing" /v "Start" /t REG_DWORD /d "4" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wersvc" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MSiSCSI" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WMPNetworkSvc" /v "Start" /t REG_DWORD /d "3" /f
     Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CDPUserSvc" /v "Start" /t REG_DWORD /d "2" /f >nul 2>&1
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WpnUserService" /v "Start" /t REG_DWORD /d "2" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanWorkstation" /v "Start" /t REG_DWORD /d "2" /f   
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\UnistoreSvc" /v "Start" /t REG_DWORD /d "3" /f 
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MapsBroker" /v "Start" /t REG_DWORD /d "2" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\debugregsvc" /v "Start" /t REG_DWORD /d "3" /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Ndu" /v "Start" /d "2" /t REG_DWORD /f  
-    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TimeBrokerSvc" /v "Start" /d "3" /t REG_DWORD /f 
-)>nul 2>&1	
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WpnUserService" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanWorkstation" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\UnistoreSvc" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MapsBroker" /v "Start" /t REG_DWORD /d "2" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\debugregsvc" /v "Start" /t REG_DWORD /d "3" /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Ndu" /v "Start" /d "2" /t REG_DWORD /f
+    Reg.exe add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TimeBrokerSvc" /v "Start" /d "3" /t REG_DWORD /f
+)>nul 2>&1
 goto tweaks
 
 :Affinity
@@ -1450,22 +1563,22 @@ echo.
 echo.
 echo.
 echo.
-echo.                                                                          %COL%[33m.  
-echo.                                                                       +N. 
-echo.                                                              //        oMMs 
-echo.                                                             +Nm`    ``yMMm- 
-echo.                                                          ``dMMsoyhh-hMMd.  
-echo.                                                          `yy/MMMMNh:dMMh`   
-echo.                                                         .hMM.sso++:oMMs`    
-echo.                                                        -mMMy:osyyys.No      
-echo.                                                       :NMMs-oo+/syy:-       
-echo.                                                      /NMN+ ``   :ys.        
-echo.                                                     `NMN:        +.         
-echo.                                                     om-                    
-echo.                                                      `.                                            
-echo. 
-echo. 
-echo. 
+echo.                                                                          %COL%[33m.
+echo.                                                                       +N.
+echo.                                                              //        oMMs
+echo.                                                             +Nm`    ``yMMm-
+echo.                                                          ``dMMsoyhh-hMMd.
+echo.                                                          `yy/MMMMNh:dMMh`
+echo.                                                         .hMM.sso++:oMMs`
+echo.                                                        -mMMy:osyyys.No
+echo.                                                       :NMMs-oo+/syy:-
+echo.                                                      /NMN+ ``   :ys.
+echo.                                                     `NMN:        +.
+echo.                                                     om-
+echo.                                                      `.
+echo.
+echo.
+echo.
 echo.
 echo.
 echo.
@@ -1487,7 +1600,7 @@ echo.
 echo                                                       [ press X to go back ]
 echo.
 echo.
-choice /c:12X /n /m "%DEL%                                                               >:"
+%SystemRoot%\System32\choice.exe /c:12X /n /m "%DEL%                                                               >:"
 if %errorlevel% equ 3 goto Tweaks
 if %errorlevel% equ 1 reg add "HKLM\SYSTEM\CurrentControlSet\Control\PriorityControl" /v "Win32PrioritySeparation" /t REG_DWORD /d "22" /f >nul 2>&1
 if %errorlevel% equ 2 reg add "HKLM\SYSTEM\CurrentControlSet\Control\PriorityControl" /v "Win32PrioritySeparation" /t REG_DWORD /d "40" /f >nul 2>&1
@@ -1628,15 +1741,15 @@ if "%CRSOF%" equ "%COL%[91mOFF" (
 goto Tweaks
 
 ::System responsiveness, PanTeR Said to use 14 (20 hexa)
-Reg add "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "SystemResponsiveness" /t Reg_DWORD /d "20" /f 
+Reg add "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "SystemResponsiveness" /t Reg_DWORD /d "20" /f
 
 ::Disable Power Throttling
-Reg delete "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /f 
+Reg delete "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /f
 ::Enable Power Throttling If Laptop
 for /f "tokens=2 delims={}" %%n in ('wmic path Win32_SystemEnclosure get ChassisTypes /value') do set /a ChassisTypes=%%n
 if defined ChassisTypes if %ChassisTypes% GEQ 8 if %ChassisTypes% LSS 12 (
-Reg add "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /v "PowerThrottlingOff" /t Reg_DWORD /d "1" /f 
-Reg add "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /f 
+Reg add "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /v "PowerThrottlingOff" /t Reg_DWORD /d "1" /f
+Reg add "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /f
 )
 
 ::::::::::::::::::::::
@@ -1644,8 +1757,8 @@ Reg add "HKLM\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" /f
 ::::::::::::::::::::::
 
 ::Reliable Timestamp
-Reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Reliability" /v "TimeStampInterval" /t Reg_DWORD /d "1" /f 
-Reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Reliability" /v "IoPriority" /t Reg_DWORD /d "3" /f 
+Reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Reliability" /v "TimeStampInterval" /t Reg_DWORD /d "1" /f
+Reg add "HKLM\Software\Microsoft\Windows\CurrentVersion\Reliability" /v "IoPriority" /t Reg_DWORD /d "3" /f
 
 :MMCSS
 Reg add "HKLM\SYSTEM\CurrentControlSet\Services\MMCSS" /v "Start" /t Reg_DWORD /d "4" /f >nul 2>&1
@@ -1658,21 +1771,18 @@ Reg add "HKLM\SYSTEM\CurrentControlSet\Services\MMCSS" /v "Start" /t Reg_DWORD /
 :HoneRenders
 ::Detect encoder for obs, blur, and ffmpeg settings
 for /F "tokens=* skip=1" %%n in ('WMIC path Win32_VideoController get Name ^| findstr "."') do set GPU_NAME=%%n
-echo %GPU_NAME% | find "NVIDIA" && set encoder=NVENC 
-echo %GPU_NAME% | find "AMD" && set encoder=AMF 
+echo %GPU_NAME% | find "NVIDIA" && set encoder=NVENC
+echo %GPU_NAME% | find "AMD" && set encoder=AMF
 if not defined encoder set encoder=CPU
-
-
-pause
 
 cls
 color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -1685,8 +1795,8 @@ echo.
 echo              %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m Install/Update OBS             %COL%[33m[ %COL%[37m2 %COL%[33m]%COL%[37m Recording                      %COL%[33m[ %COL%[37m3 %COL%[33m]%COL%[37m Streaming
 echo              %COL%[90mAutomatically install or update      %COL%[90mAutomated recording settings for     %COL%[90mAutomated streaming settings for
 echo              %COL%[90mOBS using the official link          %COL%[90mOBS based on your preference         %COL%[90mOBS based on your preference
-echo.                   
-echo.                                                                                             
+echo.
+echo.
 echo                                                           %COL%[34m%COL%[1mFFmpeg Settings%COL%[0m
 echo.
 echo              %COL%[33m[ %COL%[37m4 %COL%[33m]%COL%[37m Upscale                        %COL%[33m[ %COL%[37m5 %COL%[33m]%COL%[37m Compress                       %COL%[33m[ %COL%[37m6 %COL%[33m]%COL%[37m Preview Lag
@@ -1704,7 +1814,7 @@ echo.
 echo                                                            %COL%[34m%COL%[1mVideo Editor Settings%COL%[0m
 echo.
 echo              %COL%[33m[ %COL%[37m10 %COL%[33m]%COL%[37m Install A Video Editor (NLE)  %COL%[33m[ %COL%[37m11 %COL%[33m]%COL%[37m Project Settings              %COL%[33m[ %COL%[37m12 %COL%[33m]%COL%[37m Renders
-echo              %COL%[90mDownload ^& install a		  %COL%[90mAutomated Project settings	       %COL%[90mAutomated render settings 
+echo              %COL%[90mDownload ^& install a		  %COL%[90mAutomated Project settings	       %COL%[90mAutomated render settings
 echo		     %COL%[90mNon-Linear editing software	  %COL%[90mfor Vegas pro                        %COL%[90mfor Vegas pro
 echo.
 echo                                                 %COL%[90m[ B for back ]         %COL%[31m[ X to close ]
@@ -1732,12 +1842,13 @@ if exist "%SystemDrive%\Program Files\obs-studio\uninstall.exe" start /w "" "%Sy
 rmdir /s /q "%appdata%\obs-studio" >nul 2>&1
 
 :: get url to OBS
-for /f "skip=147 tokens=2" %%I in ('curl -s https://obsproject.com/') do set "OBS=%%I" & goto end
+for /f "skip=150 tokens=2" %%I in ('curl -s https://obsproject.com/') do set "OBS=%%I" & goto end
 :end
 :: Install OBS Silently
 curl -g -L -# -o "%temp%\OBS.exe" "%OBS:~6,84%"
 start "" /D "%temp%" OBS -s
 goto:eof
+
 
 :Recording
 cls
@@ -1745,9 +1856,9 @@ color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -1759,7 +1870,7 @@ echo.                   `.
 echo.
 echo              %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m Quality                        %COL%[33m[ %COL%[37m2 %COL%[33m]%COL%[37m Optimal                        %COL%[33m[ %COL%[37m3 %COL%[33m]%COL%[37m Performance
 echo              %COL%[90mSettings for the best                %COL%[90mThe best for performance             %COL%[90mSettings for the best
-echo              %COL%[90mquality in OBS                       %COL%[90mwithout losing any quality           %COL%[90mperformance in OBS
+echo              %COL%[90mquality in OBS                       %COL%[90mwithout losing much quality          %COL%[90mperformance in OBS
 echo.
 echo.
 echo.
@@ -1799,7 +1910,13 @@ IF %encoder% equ NVENC (
 	if not exist "%appdata%\obs-studio\basic\profiles\Untitled\basic.ini" start obs64.exe
 	taskkill /f /im obs64.exe >nul 2>&1
 	Reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%SystemDrive%\Program Files\obs-studio\bin\64bit\obs64.exe" /t Reg_SZ /d "~ RUNASADMIN" /f >nul 2>&1
+	:: get monitor resolution
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1)" > "%temp%\width.txt"
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1 -Skip 1)" > "%temp%\height.txt"
+	set /p width=<"%temp%\width.txt"
+	set /p height=<"%temp%\height.txt"
 	cls & set /p FPS="What FPS would you like to record in? >: "
+	if %FPS% gtr 120 echo Warning: Recording at high FPS with the Quality preset can cause lag on weaker systems.
 	(for %%i in (
 		"[AdvOut]"
 		"RecEncoder=jim_nvenc"
@@ -1823,10 +1940,10 @@ IF %encoder% equ NVENC (
 		"Name=Untitled"
 		.
 		"[Video]"
-		"BaseCX=1920"
-		"BaseCY=1080"
-		"OutputCX=1920"
-		"OutputCY=1080"
+		"BaseCX=!width!"
+		"BaseCY=!height!"
+		"OutputCX=!width!"
+		"OutputCY=!height!"
 		"FPSDen=1"
 		"FPSType=2"
 		"ScaleType=bilinear"
@@ -1838,8 +1955,8 @@ IF %encoder% equ NVENC (
 		"RecType=Standard"
 		"Mode=Advanced"
 	) do echo.%%~i)>"%temp%\Basic.ini"
-	echo.{"bf":0,"cqp":17,"keyint_sec":0,"lookahead":"false","preset":"hp","profile":"baseline","psycho_aq":"false","rate_control":"CQP"} >"%temp%\RecordEncoder.json"
-	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\" 
+	echo.{"bf":4,"cqp":17,"keyint_sec":5,"lookahead":"true","preset":"hq","profile":"high","psycho_aq":"true","rate_control":"CQP"} >"%temp%\RecordEncoder.json"
+	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	move /Y "%temp%\RecordEncoder.json" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	goto Recording
 ) ELSE (
@@ -1854,6 +1971,10 @@ IF %encoder% equ NVENC (
 	cd "%SystemDrive%\Program Files\obs-studio\bin\64bit"
 	taskkill /f /im obs64.exe >nul 2>&1
 	Reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%SystemDrive%\Program Files\obs-studio\bin\64bit\obs64.exe" /t Reg_SZ /d "~ RUNASADMIN" /f >nul 2>&1
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1)" > "%temp%\width.txt"
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1 -Skip 1)" > "%temp%\height.txt"
+	set /p width=<"%temp%\width.txt"
+	set /p height=<"%temp%\height.txt"
 	cls & set /p FPS="What FPS would you like to record in? >: "
 	(for %%i in (
 		"[AdvOut]"
@@ -1878,10 +1999,10 @@ IF %encoder% equ NVENC (
 		"Name=Untitled"
 		.
 		"[Video]"
-		"BaseCX=1920"
-		"BaseCY=1080"
-		"OutputCX=1920"
-		"OutputCY=1080"
+		"BaseCX=!width!"
+		"BaseCY=!height!"
+		"OutputCX=!width!"
+		"OutputCY=!height!"
 		"FPSDen=1"
 		"FPSType=2"
 		"ScaleType=bilinear"
@@ -1894,8 +2015,8 @@ IF %encoder% equ NVENC (
 		"Mode=Advanced"
 
 	) do echo.%%~i)> "%temp%\Basic.ini"
-	echo.{"bf":0,"cqp":18,"keyint_sec":0,"lookahead":"false","preset":"hp","profile":"baseline","psycho_aq":"false","rate_control":"CQP"} >"%temp%\RecordEncoder.json"
-	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\" 
+	echo.{"bf":0,"cqp":18,"keyint_sec":0,"lookahead":"false","preset":"hp","profile":"main","psycho_aq":"false","rate_control":"CQP"} >"%temp%\RecordEncoder.json"
+	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	move /Y "%temp%\RecordEncoder.json" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	goto Recording
 ) ELSE (
@@ -1910,6 +2031,10 @@ IF %encoder% equ NVENC (
 	cd "%SystemDrive%\Program Files\obs-studio\bin\64bit"
 	taskkill /f /im obs64.exe >nul 2>&1
 	Reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%SystemDrive%\Program Files\obs-studio\bin\64bit\obs64.exe" /t Reg_SZ /d "~ RUNASADMIN" /f >nul 2>&1
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1)" > "%temp%\width.txt"
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1 -Skip 1)" > "%temp%\height.txt"
+	set /p width=<"%temp%\width.txt"
+	set /p height=<"%temp%\height.txt"
 	cls & set /p FPS="What FPS would you like to record in? >: "
 	(for %%i in (
 		"[AdvOut]"
@@ -1934,10 +2059,10 @@ IF %encoder% equ NVENC (
 		"Name=Untitled"
 		.
 		"[Video]"
-		"BaseCX=1920"
-		"BaseCY=1080"
-		"OutputCX=1280"
-		"OutputCY=720"
+		"BaseCX=!width!"
+		"BaseCY=!height!"
+		"OutputCX=!width!"
+		"OutputCY=!height!"
 		"FPSDen=1"
 		"FPSType=2"
 		"ScaleType=bicubic"
@@ -1950,8 +2075,8 @@ IF %encoder% equ NVENC (
 		"Mode=Advanced"
 
 	) do echo.%%~i)> "%temp%\Basic.ini"
-	echo.{"bf":0,"cqp":18,"keyint_sec":0,"lookahead":"false","preset":"hp","profile":"baseline","psycho_aq":"false","rate_control":"CQP"} >"%temp%\RecordEncoder.json"
-	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\" 
+	echo.{"bf":0,"cqp":20,"keyint_sec":0,"lookahead":"false","preset":"hp","profile":"baseline","psycho_aq":"false","rate_control":"CQP"} >"%temp%\RecordEncoder.json"
+	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	move /Y "%temp%\RecordEncoder.json" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	goto Recording
 ) ELSE (
@@ -1967,9 +2092,9 @@ color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -1983,8 +2108,8 @@ echo                              %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m Qual
 echo                              %COL%[90mSettings for the best                                %COL%[90mSettings for the best
 echo                              %COL%[90mquality in OBS                                       %COL%[90mperformance in OBS
 echo.
-echo.                                                                                                                  
-echo.                                                                                                                  
+echo.
+echo.
 echo.
 echo.
 echo.
@@ -2019,6 +2144,10 @@ IF %encoder% equ NVENC (
 	cd "%SystemDrive%\Program Files\obs-studio\bin\64bit"
 	taskkill /f /im obs64.exe >nul 2>&1
 	Reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%SystemDrive%\Program Files\obs-studio\bin\64bit\obs64.exe" /t Reg_SZ /d "~ RUNASADMIN" /f >nul 2>&1
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1)" > "%temp%\width.txt"
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1 -Skip 1)" > "%temp%\height.txt"
+	set /p width=<"%temp%\width.txt"
+	set /p height=<"%temp%\height.txt"
 	(for %%i in (
 		"[AdvOut]"
 		"RecEncoder=jim_nvenc"
@@ -2043,10 +2172,10 @@ IF %encoder% equ NVENC (
 		"Name=Untitled"
 		.
 		"[Video]"
-		"BaseCX=1920"
-		"BaseCY=1080"
-		"OutputCX=1920"
-		"OutputCY=1080"
+		"BaseCX=!width!"
+		"BaseCY=!height!"
+		"OutputCX=!width!"
+		"OutputCY=!height!"
 		"FPSDen=1"
 		"FPSType=2"
 		"ScaleType=bilinear"
@@ -2058,8 +2187,8 @@ IF %encoder% equ NVENC (
 		"RecType=Standard"
 		"Mode=Advanced"
 	) do echo.%%~i)> "%temp%\Basic.ini"
-	echo.{"bitrate":6000,"preset":"hp","profile":"baseline","rate_control":"CBR"} >"%temp%\StreamEncoder.json"
-	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\" 
+	echo.{"bitrate":6000,"bf":4,"keyint_sec":5,"lookahead":"true","preset":"hq","profile":"high","psycho_aq":"true","rate_control":"CBR"} >"%temp%\StreamEncoder.json"
+	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	move /Y "%temp%\StreamEncoder.json" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	goto Streaming
 ) ELSE (
@@ -2074,6 +2203,10 @@ IF %encoder% equ NVENC (
 	cd "%SystemDrive%\Program Files\obs-studio\bin\64bit"
 	taskkill /f /im obs64.exe >nul 2>&1
 	Reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%SystemDrive%\Program Files\obs-studio\bin\64bit\obs64.exe" /t Reg_SZ /d "~ RUNASADMIN" /f >nul 2>&1
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1)" > "%temp%\width.txt"
+	powershell -Command "((Get-CimInstance Win32_VideoController).VideoModeDescription.Split(' x ') | Where-Object {$_ -ne ''} | Select-Object -First 1 -Skip 1)" > "%temp%\height.txt"
+	set /p width=<"%temp%\width.txt"
+	set /p height=<"%temp%\height.txt"
 	(for %%i in (
 		"[AdvOut]"
 		"RecEncoder=jim_nvenc"
@@ -2098,10 +2231,10 @@ IF %encoder% equ NVENC (
 		"Name=Untitled"
 		.
 		"[Video]"
-		"BaseCX=1920"
-		"BaseCY=1080"
-		"OutputCX=1920"
-		"OutputCY=1080"
+		"BaseCX=!width!"
+		"BaseCY=!height!"
+		"OutputCX=!width!"
+		"OutputCY=!height!"
 		"FPSDen=1"
 		"FPSType=2"
 		"ScaleType=bilinear"
@@ -2114,7 +2247,7 @@ IF %encoder% equ NVENC (
 		"Mode=Advanced"
 	) do echo.%%~i)> "%temp%\Basic.ini"
 	echo.{"bitrate":4500,"preset":"hp","profile":"baseline","rate_control":"CBR"} >"%temp%\StreamEncoder.json"
-	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\" 
+	move /Y "%temp%\basic.ini" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	move /Y "%temp%\StreamEncoder.json" "%appdata%\obs-studio\basic\profiles\Untitled\"
 	goto Streaming
 ) ELSE (
@@ -2130,9 +2263,9 @@ color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -2145,8 +2278,8 @@ echo.
 echo                            %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m 4k                                             %COL%[33m[ %COL%[37m2 %COL%[33m]%COL%[37m 8k
 echo                            %COL%[90mModify the scale of a video                          %COL%[90mModify the scale of a video
 echo                            %COL%[90mto turn it to 4k                                     %COL%[90mto turn it to 8k
-echo. 
-echo.                                                                                                                  
+echo.
+echo.
 echo.
 echo.
 echo.
@@ -2180,16 +2313,16 @@ goto upscale
 cls
 set /p "file= Drag the file you want upscaled into this window >> "
 IF %encoder% equ NVENC (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i %file% -vf scale=3840:2160:flags=neighbor -r 60 -vcodec h264_nvenc -profile:v high -preset fast -rc constqp -qp 14 "%SystemDrive%\users\%username%\desktop\4k.mp4" -y
+%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -vf scale=-2:2160:flags=neighbor -c:v hevc_nvenc -preset p7 -rc vbr -b:v 250M -cq 20 -pix_fmt yuv420p10le "%userprofile%\desktop\4k.mp4" -y
 ) else (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i %file% -vf scale=3840:2160:flags=neighbor -r 60 -vcodec h264_amf -profile:v high -preset fast -qmin 13 -qmax 13 "%SystemDrive%\users\%username%\desktop\4k.mp4" 
+%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -vf scale=-2:2160:flags=neighbor -c:v hevc_amf -quality quality -qp_i 18 -qp_p 20 -qp_b 24 -pix_fmt yuv420p10le "%userprofile%\desktop\4k.mp4"
 )
 goto upscale
 
 :8k
 cls
 set /p "file= Drag the file you want upscaled into this window >> "
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i %file% -vf scale=7680:4320:flags=neighbor -r 60 -vcodec libx264 -profile:v high -preset fast -qmin 19 -qmax 19 "%SystemDrive%\users\%username%\desktop\8k.mp4" 
+%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -vf scale=-2:4320:flags=neighbor -c:v libx264 -preset slow -aq-mode 3 -crf 22 -pix_fmt yuv420p10le "%userprofile%\desktop\8k.mp4"
 goto upscale
 
 
@@ -2200,9 +2333,9 @@ color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -2213,10 +2346,10 @@ echo.                  om-                                                      
 echo.                   `.
 echo.
 echo                         %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m Heavy                                          %COL%[33m[ %COL%[37m2 %COL%[33m]%COL%[37m Light
-echo                         %COL%[90mLower the scale ^& fps of a video                     %COL%[90mLower only the scale of a video
+echo                         %COL%[90mCompress a video                     	 	     %COL%[90mCompress a video
 echo                         %COL%[90mto make it take up much less space                   %COL%[90mto make it take up less space
 echo.
-echo.                                                                                                                  
+echo.
 echo.
 echo.
 echo.
@@ -2248,42 +2381,32 @@ goto compress
 
 :heavy
 cls
-set /p "file= Drag the file you want upscaled into this window >> "
-IF %encoder% equ NVENC (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i %file% -vf scale=800:600:flags=neighbor -r 48 -vcodec h264_nvenc -profile:v high -preset fast -rc constqp -qp 14 "%SystemDrive%\users\%username%\desktop\heavycompress.mp4" -y
-) else (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i %file% -vf scale=800:600:flags=neighbor -r 48 -vcodec h264_amf -profile:v high -preset fast -qmin 13 -qmax 13 "%SystemDrive%\users\%username%\desktop\heavycompress.mp4" 
-)
+set /p "file= Drag the file you want compressed into this window >> "
+%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -vf scale=-2:ih*0.75:flags=bicubic -c:v libx264 -preset slower -crf 23 -aq-mode 3 -c:a aac -b:a 128k "%userprofile%\desktop\heavycompress.mp4" -y
 goto compress
 
 :Light
 cls
-set /p "file= Drag the file you want upscaled into this window >> "
-IF %encoder% equ NVENC (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i %file% -vf scale=1280:720:flags=neighbor -r 60 -vcodec h264_nvenc -profile:v high -preset fast -rc constqp -qp 14 "%SystemDrive%\users\%username%\desktop\lightcompress.mp4" -y
-) else (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i %file% -vf scale=1280:720:flags=neighbor -r 60 -vcodec h264_amf -profile:v high -preset fast -qmin 13 -qmax 13 "%SystemDrive%\users\%username%\desktop\lightcompress.mp4" 
-)
+set /p "file= Drag the file you want compressed into this window >> "
+%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -c:v libx264 -preset slow -crf 18 -aq-mode 3 -c:a aac -b:a 256k "%userprofile%\desktop\lightcompress.mp4" -y
 goto compress
 
 :PreviewLag
 if not exist %SystemDrive%\ffmpeg ( call:ffmpeginstall )
 cls
 set /p "file= Drag the file you want to use in vegas (remember you need to replace it with the original file afterwards) >> "
-IF %encoder% equ NVENC (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -vf scale=1920:1080:flags=neighbor -r 60 -vcodec h264_nvenc -profile:v high -preset fast -qmin 24 -qmax 24 "%SystemDrive%\users\%username%\desktop\previewlag.mp4" -y
-) else (
-%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -vf scale=1920:1080:flags=neighbor -r 60 -vcodec h264_amf -profile:v high -preset fast -qmin 24 -qmax 24 "%SystemDrive%\users\%username%\desktop\previewlag.mp4"
-)
+%SystemDrive%\ffmpeg\bin\ffmpeg.exe -i "%file%" -vf scale=-2:ih/2:flags=bicubic -c:v libx264 -preset superfast -crf 23 -tune fastdecode -c:a copy "%userprofile%\desktop\previewlag.mp4" -y
 goto HoneRenders
 
 :ffmpeginstall
 cls
 echo FFmpeg not found... Installing...
-curl -g -L -# -o "%temp%\ffmpeg.exe" "https://cdn.discordapp.com/attachments/798652558351794196/809493909704015892/ffmpeg-4.2-setup.exe"
-"%temp%\ffmpeg.exe" /SP /VERYSILENT /SUPPRESSMSGBOXES /NOCANCEL /NORESTART /ALLUSERS
+curl -g -L -# -o "%temp%\ffmpeg.zip" "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
+powershell -Command "Expand-Archive -Path %temp%\ffmpeg.zip -DestinationPath %SystemDrive%\ffmpeg"
+powershell -Command "Convert-Path 'C:\ffmpeg\ffmpeg-*-essentials_build\*' | ForEach-Object {Move-Item $_ 'C:\ffmpeg'}"
+powershell -Command "Convert-Path 'C:\ffmpeg\ffmpeg-*-essentials_build\' | Remove-Item"
 goto:eof
- 
+
 :blurinstall
 :: delete old blur
 rmdir /s /q "%SystemDrive%\program files (x86)\blur"
@@ -2298,9 +2421,9 @@ color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -2314,7 +2437,7 @@ echo                       %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m 60 - 120 FP
 echo                       %COL%[90mAutomated Blur settings                              %COL%[90mAutomated Blur settings
 echo                       %COL%[90mfor FPS games recorded in 60 to 120 FPS              %COL%[90mfor FPS games recorded in above 240 FPS
 echo.
-echo.                                                                                                                  
+echo.
 echo.
 echo.
 echo.
@@ -2346,7 +2469,7 @@ goto FPSGames
 
 :60120
 if not exist "%SystemDrive%\Program Files (x86)\blur" call:blurinstall
-if exist "%SystemDrive%\users\%username%\documents\HoneFPS60-120.cfg" goto skip
+if exist "%userprofile%\documents\HoneFPS60-120.cfg" goto skip
 if %encoder% equ NVENC (
 	(for %%i in (
 		"- blur"
@@ -2361,7 +2484,7 @@ if %encoder% equ NVENC (
 		.
 		"- rendering"
 		"quality: 15"
-		"preview: true"
+		"preview: false"
 		"detailed filenames: false"
 		.
 		"- timescale"
@@ -2378,19 +2501,19 @@ if %encoder% equ NVENC (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): nvidia"
 		"deduplicate: false"
-		"custom ffmpeg filters:" 
+		"custom ffmpeg filters: -c:v h264_nvenc -preset p7 -rc vbr -b:v 250M -cq 18 -c:a copy"
 		.
 		"- advanced blur"
 		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1]"
+		"blur weighting bound: [0,2]"
 		.
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
 		"interpolation speed: medium"
 		"interpolation tuning: film"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS60-120.cfg"
+	) do echo.%%~i)> "%userprofile%\Documents\HoneFPS60-120.cfg"
 )
 
 if %encoder% equ AMF (
@@ -2407,7 +2530,7 @@ if %encoder% equ AMF (
 		.
 		"- rendering"
 		"quality: 15"
-		"preview: true"
+		"preview: false"
 		"detailed filenames: false"
 		.
 		"- timescale"
@@ -2424,19 +2547,19 @@ if %encoder% equ AMF (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): amd"
 		"deduplicate: false"
-		"custom ffmpeg filters:" 
+		"custom ffmpeg filters: -c:v h264_amf -quality quality -qp_i 16 -qp_p 18 -qp_b 22 -c:a copy"
 		.
 		"- advanced blur"
 		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1]"
+		"blur weighting bound: [0,2]"
 		.
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
 		"interpolation speed: medium"
 		"interpolation tuning: film"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS60-120.cfg"
+	) do echo.%%~i)> "%userprofile%\Documents\HoneFPS60-120.cfg"
 )
 
 if %encoder% equ CPU (
@@ -2453,7 +2576,7 @@ if %encoder% equ CPU (
 		.
 		"- rendering"
 		"quality: 15"
-		"preview: true"
+		"preview: false"
 		"detailed filenames: false"
 		.
 		"- timescale"
@@ -2470,31 +2593,31 @@ if %encoder% equ CPU (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): intel"
 		"deduplicate: false"
-		"custom ffmpeg filters:" 
+		"custom ffmpeg filters: -c:v libx264 -preset slow -aq-mode 3 -crf 17 -c:a copy"
 		.
 		"- advanced blur"
 		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1]"
+		"blur weighting bound: [0,2]"
 		.
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
 		"interpolation speed: medium"
 		"interpolation tuning: film"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS60-120.cfg"
+	) do echo.%%~i)> "%userprofile%\Documents\HoneFPS60-120.cfg"
 )
 
 :skip
 cls
 set /p "file= Print the path of the file you want blurred into this window >> "
-"%SystemDrive%\program files (x86)\blur\blur.exe" -i %file% -c "%SystemDrive%\users\%username%\Documents\HoneFPS60-120.cfg" -n -p -v
+"%SystemDrive%\program files (x86)\blur\blur.exe" -i %file% -c "%userprofile%\Documents\HoneFPS60-120.cfg" -n -p -v
 goto HoneRenders
 
 
 :240
 if not exist "%SystemDrive%\Program Files (x86)\blur\" call:blurinstall
-if exist "%SystemDrive%\users\%username%\documents\HoneFPS240+.cfg" goto skip
+if exist "%userprofile%\documents\HoneFPS240+.cfg" goto skip
 if %encoder% equ NVENC (
 	(for %%i in (
 		"- blur"
@@ -2505,11 +2628,11 @@ if %encoder% equ NVENC (
 		.
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 960"
+		"interpolated fps: 1440
 		.
 		"- rendering"
 		"quality: 15"
-		"preview: true"
+		"preview: false"
 		"detailed filenames: false"
 		.
 		"- timescale"
@@ -2526,19 +2649,19 @@ if %encoder% equ NVENC (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): nvidia"
 		"deduplicate: false"
-		"custom ffmpeg filters:"
+		"custom ffmpeg filters: -c:v h264_nvenc -preset p7 -rc vbr -b:v 250M -cq 18 -c:a copy"
 		.
 		"- advanced blur"
 		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1]"
+		"blur weighting bound: [0,2]"
 		.
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
 		"interpolation speed: medium"
 		"interpolation tuning: weak"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS240+.cfg"
+	) do echo.%%~i)> "%userprofile%\Documents\HoneFPS240+.cfg"
 )
 
 if %encoder% equ AMF (
@@ -2555,7 +2678,7 @@ if %encoder% equ AMF (
 		.
 		"- rendering"
 		"quality: 15"
-		"preview: true"
+		"preview: false"
 		"detailed filenames: false"
 		.
 		"- timescale"
@@ -2572,20 +2695,20 @@ if %encoder% equ AMF (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): amd"
 		"deduplicate: false"
-		"custom ffmpeg filters:"
+		"custom ffmpeg filters: -c:v h264_amf -quality quality -qp_i 16 -qp_p 18 -qp_b 22 -c:a copy"
 		.
 		"- advanced blur"
 		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1]"
+		"blur weighting bound: [0,2]"
 		.
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
 		"interpolation speed: medium"
 		"interpolation tuning: weak"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS240+.cfg"
-) 
+	) do echo.%%~i)> "%userprofile%\Documents\HoneFPS240+.cfg"
+)
 
 if %encoder% equ CPU (
 	(for %%i in (
@@ -2597,7 +2720,7 @@ if %encoder% equ CPU (
 		.
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 960"
+		"interpolated fps: 1440"
 		.
 		"- rendering"
 		"quality: 15"
@@ -2618,25 +2741,25 @@ if %encoder% equ CPU (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): intel"
 		"deduplicate: false"
-		"custom ffmpeg filters:"
+		"custom ffmpeg filters: -c:v libx264 -preset slow -aq-mode 3 -crf 17 -c:a copy"
 		.
 		"- advanced blur"
 		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1]"
+		"blur weighting bound: [0,2]"
 		.
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
 		"interpolation speed: medium"
 		"interpolation tuning: weak"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS240+.cfg"
+	) do echo.%%~i)> "%userprofile%\Documents\HoneFPS240+.cfg"
 )
 
 :skip
 cls
 set /p "file= Print the path of the file you want blurred into this windoww >> "
-"%SystemDrive%\program files (x86)\blur\blur.exe" -i %file% -c "%SystemDrive%\users\%username%\Documents\HoneFPS240+.cfg" -n -p -v
+"%SystemDrive%\program files (x86)\blur\blur.exe" -i %file% -c "%userprofile%\Documents\HoneFPS240+.cfg" -n -p -v
 goto HoneRenders
 
 :MinecraftBlur
@@ -2645,9 +2768,9 @@ color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -2656,13 +2779,14 @@ echo.                   /NMN+ ``   :ys.      ########     ###    ####    #######
 echo.                  `NMN:        +.                                                      ##    ###     ##    ###
 echo.                  om-                                                                   #######       #######
 echo.                   `.
+echo				%COL%[33m%COL%[4mDisclaimer: Using Blur is not recommended for Minecraft clips below 180 FPS.%COL%[0m
 echo.
-echo         %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m 180 - 360 FPS                       %COL%[33m[ %COL%[37m2 %COL%[33m]%COL%[37m 480+ FPS                        %COL%[33m[ %COL%[37m3 %COL%[33m]%COL%[37m Any FPS (30 FPS Renders)
-echo         %COL%[90mAutomated Blur settings                   %COL%[90mAutomated Blur settings               %COL%[90mAutomated Blur settings
-echo         %COL%[90mfor clips recorded in 180 - 360 FPS       %COL%[90mfor clips recorded above 480 FPS      %COL%[90mfor clips to be rendered in 30 FPS
+echo         		%COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m 180+ FPS (60 FPS Renders)                    %COL%[33m[ %COL%[37m2 %COL%[33m]%COL%[37m 180+ FPS (30 FPS Renders)
+echo         		%COL%[90mAutomated Blur settings                            %COL%[90mAutomated Blur settings
+echo         		%COL%[90mfor clips recorded in 180+ FPS                     %COL%[90mfor clips to be rendered in 30 FPS
 echo.
 echo.
-echo.                                                                                                                  
+echo.
 echo.
 echo.
 echo.
@@ -2685,27 +2809,26 @@ echo.
 echo                                                 %COL%[90m[ B for back ]         %COL%[31m[ X to close ]
 echo.
 set /p choice="%DEL%                                        %COL%[37mSelect a corresponding number to the options above > "
-if /i "%choice%"=="1" goto 180360
-if /i "%choice%"=="2" goto 480
-if /i "%choice%"=="3" goto Any
+if /i "%choice%"=="1" goto 180plus
+if /i "%choice%"=="2" goto 30fps
 if /i "%choice%"=="B" goto HoneRenders
 if /i "%choice%"=="X" exit /b
 goto MinecraftBlur
 
-:180360
+:180plus
 if not exist "%SystemDrive%\Program Files (x86)\blur\" call:blurinstall
-if exist "%SystemDrive%\users\%username%\documents\HoneFPS180-360FPS.cfg" goto skip
+if exist "%userprofile%\documents\HoneMC180plusFPS.cfg" goto skip
 if %encoder% equ NVENC (
 	(for %%i in (
 		"- blur"
 		"blur: true"
-		"blur amount: 1.6"
+		"blur amount: 1.3"
 		"blur output fps: 60"
 		"blur weighting: gaussian_sym"
 
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 1920"
+		"interpolated fps: 1980"
 
 		"- rendering"
 		"quality: 15"
@@ -2726,10 +2849,10 @@ if %encoder% equ NVENC (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): nvidia"
 		"deduplicate: true"
-		"custom ffmpeg filters: "
+		"custom ffmpeg filters: -c:v h264_nvenc -preset p7 -rc vbr -b:v 250M -cq 18 -c:a copy"
 
 		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
+		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
 		"blur weighting bound: [0,1]"
 
@@ -2738,20 +2861,20 @@ if %encoder% equ NVENC (
 		"interpolation speed: medium"
 		"interpolation tuning: weak"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS180-360FPS.cfg"
+	) do echo.%%~i)> "%userprofile%\documents\HoneMC180plusFPS.cfg"
 )
 
 if %encoder% equ AMF (
 	(for %%i in (
 		"- blur"
 		"blur: true"
-		"blur amount: 1.6"
+		"blur amount: 1.3"
 		"blur output fps: 60"
 		"blur weighting: gaussian_sym"
 
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 1920"
+		"interpolated fps: 1980"
 
 		"- rendering"
 		"quality: 15"
@@ -2772,10 +2895,10 @@ if %encoder% equ AMF (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): amd"
 		"deduplicate: true"
-		"custom ffmpeg filters: "
+		"custom ffmpeg filters: -c:v h264_amf -quality quality -qp_i 16 -qp_p 18 -qp_b 22 -c:a copy"
 
 		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
+		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
 		"blur weighting bound: [0,1]"
 
@@ -2784,20 +2907,20 @@ if %encoder% equ AMF (
 		"interpolation speed: medium"
 		"interpolation tuning: weak"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS180-360FPS.cfg"
-) 
+	) do echo.%%~i)> "%userprofile%\documents\HoneMC180plusFPS.cfg"
+)
 
 if %encoder% equ CPU (
 	(for %%i in (
 		"- blur"
 		"blur: true"
-		"blur amount: 1.6"
+		"blur amount: 1.3"
 		"blur output fps: 60"
 		"blur weighting: gaussian_sym"
 
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 1920"
+		"interpolated fps: 1980"
 
 		"- rendering"
 		"quality: 15"
@@ -2818,10 +2941,10 @@ if %encoder% equ CPU (
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): intel"
 		"deduplicate: true"
-		"custom ffmpeg filters: "
+		"custom ffmpeg filters: -c:v libx264 -preset slow -aq-mode 3 -crf 17 -c:a copy"
 
 		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
+		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
 		"blur weighting bound: [0,1]"
 
@@ -2830,307 +2953,160 @@ if %encoder% equ CPU (
 		"interpolation speed: medium"
 		"interpolation tuning: weak"
 		"interpolation algorithm: 13"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS180-360FPS.cfg"
+	) do echo.%%~i)> "%userprofile%\documents\HoneMC180plusFPS.cfg"
 )
 
 :skip
 cls
 set /p "file= Print the path of the file you want blurred into this window >> "
-"%SystemDrive%\program files (x86)\blur\blur.exe" -i %file% -c "%SystemDrive%\users\%username%\Documents\HoneFPS180-360FPS.cfg" -n -p -v
+"%SystemDrive%\program files (x86)\blur\blur.exe" -i "%file%" -c "%userprofile%\documents\HoneMC180plusFPS.cfg" -n -p -v
 goto HoneRenders
 
-:480
-if not exist "%SystemDrive%\Program Files (x86)\blur\" cls & echo blur isn't installed... & timeout 3 & goto HoneRenders
-if exist "%SystemDrive%\users\%username%\documents\HoneFPS480FPS.cfg" goto skip
+:30fps
+if not exist "%SystemDrive%\Program Files (x86)\blur\" call:blurinstall
+if exist "%userprofile%\documents\HoneMC30FPS.cfg" goto skip
 if %encoder% equ NVENC (
 	(for %%i in (
 		"- blur"
 		"blur: true"
-		"blur amount: 2.22"
-		"blur output fps: 60"
-		"blur weighting: gaussian_sym"
-		.
+		"blur amount: 1"
+		"blur output fps: 30"
+		"blur weighting: equal"
+
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 1920"
-		.
+		"interpolated fps: 720"
+
 		"- rendering"
 		"quality: 15"
 		"preview: true"
 		"detailed filenames: false"
-		.
+
 		"- timescale"
 		"input timescale: 1"
 		"output timescale: 1"
 		"adjust timescaled audio pitch: false"
-		.
+
 		"- filters"
 		"brightness: 1"
 		"saturation: 1"
 		"contrast: 1"
-		.
+
 		"- advanced rendering"
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): nvidia"
-		"deduplicate: false"
-		"custom ffmpeg filters:" 
-		.
+		"deduplicate: true"
+		"custom ffmpeg filters: -c:v h264_nvenc -preset p7 -rc vbr -b:v 250M -cq 18 -c:a copy"
+
 		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
+		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,2]"
-		.
+		"blur weighting bound: [0,1]"
+
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
-		"interpolation speed: faster"
+		"interpolation speed: medium"
 		"interpolation tuning: weak"
-		"interpolation algorithm: 2"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS480FPS.cfg"
+		"interpolation algorithm: 13"
+	) do echo.%%~i)> "%userprofile%\documents\HoneMC30FPS.cfg"
 )
 
 if %encoder% equ AMF (
 	(for %%i in (
 		"- blur"
 		"blur: true"
-		"blur amount: 2.22"
-		"blur output fps: 60"
-		"blur weighting: gaussian_sym"
-		.
+		"blur amount: 1"
+		"blur output fps: 30"
+		"blur weighting: equal"
+
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 1920"
-		.
+		"interpolated fps: 720"
+
 		"- rendering"
 		"quality: 15"
 		"preview: true"
 		"detailed filenames: false"
-		.
+
 		"- timescale"
 		"input timescale: 1"
 		"output timescale: 1"
 		"adjust timescaled audio pitch: false"
-		.
+
 		"- filters"
 		"brightness: 1"
 		"saturation: 1"
 		"contrast: 1"
-		.
+
 		"- advanced rendering"
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): amd"
-		"deduplicate: false"
-		"custom ffmpeg filters:" 
-		.
+		"deduplicate: true"
+		"custom ffmpeg filters: -c:v h264_amf -quality quality -qp_i 16 -qp_p 18 -qp_b 22 -c:a copy"
+
 		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
+		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,2]"
-		.
+		"blur weighting bound: [0,1]"
+
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
-		"interpolation speed: faster"
+		"interpolation speed: medium"
 		"interpolation tuning: weak"
-		"interpolation algorithm: 2"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS480FPS.cfg"
-) 
+		"interpolation algorithm: 13"
+	) do echo.%%~i)> "%userprofile%\documents\HoneMC30FPS.cfg"
+)
 
 if %encoder% equ CPU (
 	(for %%i in (
 		"- blur"
 		"blur: true"
-		"blur amount: 2.22"
-		"blur output fps: 60"
-		"blur weighting: gaussian_sym"
-		.
+		"blur amount: 1"
+		"blur output fps: 30"
+		"blur weighting: equal"
+
 		"- interpolation"
 		"interpolate: true"
-		"interpolated fps: 1920"
-		.
+		"interpolated fps: 720"
+
 		"- rendering"
 		"quality: 15"
 		"preview: true"
 		"detailed filenames: false"
-		.
+
 		"- timescale"
 		"input timescale: 1"
 		"output timescale: 1"
 		"adjust timescaled audio pitch: false"
-		.
+
 		"- filters"
 		"brightness: 1"
 		"saturation: 1"
 		"contrast: 1"
-		.
+
 		"- advanced rendering"
 		"gpu: true"
 		"gpu type (nvidia/amd/intel): intel"
-		"deduplicate: false"
-		"custom ffmpeg filters:" 
-		.
+		"deduplicate: true"
+		"custom ffmpeg filters: -c:v libx264 -preset slow -aq-mode 3 -crf 17 -c:a copy"
+
 		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
+		"blur weighting gaussian std dev: 2"
 		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,2]"
-		.
+		"blur weighting bound: [0,1]"
+
 		"- advanced interpolation"
 		"interpolation program (svp/rife/rife-ncnn): svp"
-		"interpolation speed: faster"
+		"interpolation speed: medium"
 		"interpolation tuning: weak"
-		"interpolation algorithm: 2"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneFPS480FPS.cfg"
+		"interpolation algorithm: 13"
+	) do echo.%%~i)> "%userprofile%\documents\HoneMC30FPS.cfg"
 )
 
 :skip
 cls
 set /p "file= Print the path of the file you want blurred into this window >> "
-"%SystemDrive%\program files (x86)\blur\blur.exe" -i %file% -c "%SystemDrive%\users\%username%\Documents\HoneFPS480FPS.cfg" -n -p -v
-goto HoneRenders
-
-:Any
-if not exist "%SystemDrive%\Program Files (x86)\blur\" cls & echo blur isn't installed... & timeout 3 & goto HoneRenders
-if exist "%SystemDrive%\users\%username%\documents\HoneAnyFPS.cfg" goto skip
-if %encoder% equ NVENC (
-	(for %%i in (
-		"- blur"
-		"blur: true"
-		"blur amount: 1.1"
-		"blur output fps: 30"
-		"blur weighting: equal"
-		.
-		"- interpolation"
-		"interpolate: true"
-		"interpolated fps: 1920"
-		.
-		"- rendering"
-		"quality: 15"
-		"preview: true"
-		"detailed filenames: false"
-		.
-		"- timescale"
-		"input timescale: 1"
-		"output timescale: 1"
-		"adjust timescaled audio pitch: false"
-		.
-		"- filters"
-		"brightness: 1"
-		"saturation: 1"
-		"contrast: 1"
-		.
-		"- advanced rendering"
-		"gpu: true"
-		"gpu type (nvidia/amd/intel): nvidia"
-		"deduplicate: true"
-		"custom ffmpeg filters: "
-		.
-		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
-		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1,1,1,1,0]"
-		.
-		"- advanced interpolation"
-		"interpolation program (svp/rife/rife-ncnn): svp"
-		"interpolation speed: medium"
-		"interpolation tuning: weak"
-		"interpolation algorithm: 23"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneAnyFPS.cfg"
-)
-
-if %encoder% equ AMF (
-	(for %%i in (
-		"- blur"
-		"blur: true"
-		"blur amount: 1.1"
-		"blur output fps: 30"
-		"blur weighting: equal"
-		.
-		"- interpolation"
-		"interpolate: true"
-		"interpolated fps: 1920"
-		.
-		"- rendering"
-		"quality: 15"
-		"preview: true"
-		"detailed filenames: false"
-		.
-		"- timescale"
-		"input timescale: 1"
-		"output timescale: 1"
-		"adjust timescaled audio pitch: false"
-		.
-		"- filters"
-		"brightness: 1"
-		"saturation: 1"
-		"contrast: 1"
-		.
-		"- advanced rendering"
-		"gpu: true"
-		"gpu type (nvidia/amd/intel): amd"
-		"deduplicate: true"
-		"custom ffmpeg filters: "
-		.
-		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
-		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1,1,1,1,0]"
-		.
-		"- advanced interpolation"
-		"interpolation program (svp/rife/rife-ncnn): svp"
-		"interpolation speed: medium"
-		"interpolation tuning: weak"
-		"interpolation algorithm: 23"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneAnyFPS.cfg"
-) 
-
-if %encoder% equ CPU (
-	(for %%i in (
-		"- blur"
-		"blur: true"
-		"blur amount: 1.1"
-		"blur output fps: 30"
-		"blur weighting: equal"
-		.
-		"- interpolation"
-		"interpolate: true"
-		"interpolated fps: 1920"
-		.
-		"- rendering"
-		"quality: 15"
-		"preview: true"
-		"detailed filenames: false"
-		.
-		"- timescale"
-		"input timescale: 1"
-		"output timescale: 1"
-		"adjust timescaled audio pitch: false"
-		.
-		"- filters"
-		"brightness: 1"
-		"saturation: 1"
-		"contrast: 1"
-		.
-		"- advanced rendering"
-		"gpu: true"
-		"gpu type (nvidia/amd/intel): intel"
-		"deduplicate: true"
-		"custom ffmpeg filters: "
-		.
-		"- advanced blur"
-		"blur weighting gaussian std dev: 1"
-		"blur weighting triangle reverse: false"
-		"blur weighting bound: [0,1,1,1,1,0]"
-		.
-		"- advanced interpolation"
-		"interpolation program (svp/rife/rife-ncnn): svp"
-		"interpolation speed: medium"
-		"interpolation tuning: weak"
-		"interpolation algorithm: 23"
-	) do echo.%%~i)> "%SystemDrive%\users\%username%\Documents\HoneAnyFPS.cfg"
-)
-
-:skip
-cls
-set /p "file= Print the path of the file you want blurred into this window >> "
-"%SystemDrive%\program files (x86)\blur\blur.exe" -i %file% -c "%SystemDrive%\users\%username%\Documents\HoneAnyFPS.cfg" -n -p -v
+"%SystemDrive%\program files (x86)\blur\blur.exe" -i "%file%" -c "%userprofile%\documents\HoneMC30FPS.cfg" -n -p -v
 goto HoneRenders
 
 :NLEInstall
@@ -3139,9 +3115,9 @@ color 06
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -3150,16 +3126,16 @@ echo.                   /NMN+ ``   :ys.      ########     ###    ####    #######
 echo.                  `NMN:        +.                                                      ##    ###     ##    ###
 echo.                  om-                                                                   #######       #######
 echo.                   `.
-echo                       %COL%[90mUnfortunately, Hone cannot supply unofficial distributions of software. If you 
+echo                       %COL%[90mUnfortunately, Hone cannot supply unofficial distributions of software. If you
 echo                       %COL%[90mcannot buy Vegas Pro, an alternative that we recommend is a freemium video editing software
 echo                       %COL%[90mcalled 'DaVinci Resolve' (note: this program does not contain render settings)^^!
 echo.
 echo.
 echo                           %COL%[33m[ %COL%[37m1 %COL%[33m]%COL%[37m Vegas Pro website                        %COL%[33m[ %COL%[37m2 %COL%[33m]%COL%[37m DaVinci Resolve website
 echo                           %COL%[90mPaid with supported renders                    %COL%[90mFree but unsupported renders
-echo.                                                                           
 echo.
-echo.                                                                                                                  
+echo.
+echo.
 echo.
 echo.
 echo.
@@ -3234,9 +3210,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -3308,9 +3284,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -3322,12 +3298,12 @@ echo.                   `.
 echo                                                           %COL%[1;4;34mNetwork Tweaks%COL%[0m
 echo.
 echo              %COL%[33m[%COL%[37m 1 %COL%[33m]%COL%[37m Disable Task Offloading %TOFOF%    %COL%[33m[%COL%[37m 2 %COL%[33m]%COL%[37m NonBestEffortLimit %NONOF%         %COL%[33m[%COL%[37m 3 %COL%[33m]%COL%[37m AutoTuning %AUTOF%
-echo              %COL%[90mTask Offloading assigns the          %COL%[90mAllocate more bandwidth to apps      %COL%[90mCan reduce bufferbloat, 
+echo              %COL%[90mTask Offloading assigns the          %COL%[90mAllocate more bandwidth to apps      %COL%[90mCan reduce bufferbloat,
 echo              %COL%[90mCPU to handle the NIC load           %COL%[90mUse only on fast connections         %COL%[90mbut lower your Network speed
 echo.
-echo                           %COL%[33m[%COL%[37m 4 %COL%[33m]%COL%[37m DSCP Value %DSCOF%                     %COL%[33m[%COL%[37m 5 %COL%[33m]%COL%[37m Wifi Congestion Provider %CONG% 
-echo                           %COL%[90mSet the priority of your network         %COL%[90mTurn ON only, if you have WIFI. 
-echo                           %COL%[90mtraffic to expedited forwarding          %COL%[90mChanges the algorithm on how data is processed.
+echo                           %COL%[33m[%COL%[37m 4 %COL%[33m]%COL%[37m DSCP Value %DSCOF%                      %COL%[33m[%COL%[37m 5 %COL%[33m]%COL%[37m Wi-fi Congestion Provider %CONG%
+echo                           %COL%[90mSet the priority of your network          %COL%[91mTurn ON only, if you have Wi-Fi.
+echo                           %COL%[90mtraffic to expedited forwarding           %COL%[90mChanges the algorithm on how data is processed.
 echo.
 echo.
 echo                                                            %COL%[1;4;34mPower Tweaks%COL%[0m
@@ -3395,6 +3371,41 @@ if "%AUTOF%" equ "%COL%[91mOFF" (
 goto Advanced
 
 :Congestion
+Reg query "HKCU\Software\Hone" /v "WifiDisclaimer3" >nul 2>&1 && goto Congestion2
+cls
+echo.
+echo.
+echo.                                      %COL%[33m+N.
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
+echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
+echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
+echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
+echo.                    :NMMs-oo+/syy:-     #+#    #+#    #+#   #+#+#    #+#          %COL%[37m#+#%COL%[33m    +#+   #+#     #+#   #+#
+echo.                   /NMN+ ``   :ys.      ########     ###    ####    ##########   %COL%[37m###%COL%[33m       ######        ######
+echo.                  `NMN:        +.                                                      ##    ###     ##    ###
+echo.                  om-                                                                   #######       #######
+echo.                   `.
+echo.
+echo                                        %COL%[90m HoneCtrl is a free and open-source desktop utility
+echo                                        %COL%[90m    made to improve your day-to-day productivity
+echo.
+echo.
+echo.
+echo %COL%[91m  WARNING:
+echo %COL%[91m  This tweak is for Wi-Fi users only, if you're on Ethernet, do not run this tweak.
+echo.
+echo   %COL%[37mFor any questions and/or concerns, please join our discord: discord.gg/hone
+echo.
+echo   %COL%[37mPlease enter "I understand" without quotes to continue:
+echo.
+echo.
+echo.
+set /p "input=%DEL%                                                            >: %COL%[92m"
+if /i "!input!" neq "i understand" goto Tweaks
+Reg add "HKCU\Software\Hone" /v "WifiDisclaimer3" /f >nul 2>&1
+:Congestion2
 if "%CONG%" equ "%COL%[91mOFF" (
 	Reg add "HKCU\Software\Hone" /v TuningTweak1 /f >nul 2>&1
     netsh int tcp set supplemental Internet congestionprovider=newreno >nul 2>&1
@@ -3406,7 +3417,7 @@ goto Advanced
 
 :DSCPValue
 if "%DSCOF%" equ "%COL%[91mOFF" (
-	Reg add "HKLM\SYSTEM\CurrentControlSet\Services\Psched" /v "Start" /t Reg_DWORD /d "1" /f  
+	Reg add "HKLM\SYSTEM\CurrentControlSet\Services\Psched" /v "Start" /t Reg_DWORD /d "1" /f
 	sc start Psched
 	for %%i in (csgo VALORANT-Win64-Shipping javaw FortniteClient-Win64-Shipping ModernWarfare r5apex) do (
 		Reg query "HKLM\Software\Policies\Microsoft\Windows\QoS\%%i" || (
@@ -3477,10 +3488,10 @@ cls
 echo This will uninstall your current graphics driver. The optimized driver will be installed after you reboot.
 echo.
 echo Would you like to install?
-choice /c:YN /n /m "[Y] Yes  [N] No"
+%SystemRoot%\System32\choice.exe /c:YN /n /m "[Y] Yes  [N] No"
 if %errorlevel% equ 2 goto Advanced
 cd "%appdata%\Microsoft\Windows\Start Menu\Programs\Startup"
-curl -LJ https://github.com/RadNotRed/HoneCtrl/blob/main/Files/Driverinstall.bat?raw=true -o Driverinstall.bat 
+curl -LJ https://github.com/RadNotRed/HoneCtrl/blob/main/Files/Driverinstall.bat?raw=true -o Driverinstall.bat
 title Executing DDU...
 curl -g -L -# -o "C:\Hone\Resources\DDU.zip" "https://github.com/auraside/HoneCtrl/raw/main/Files/DDU.zip"
 powershell -NoProfile Expand-Archive 'C:\Hone\Resources\DDU.zip' -DestinationPath 'C:\Hone\Resources\DDU\' >nul 2>&1
@@ -3496,7 +3507,7 @@ echo.
 echo Drivers will be installed opon PC startup.
 echo.
 echo Would you like to continue and restart your PC?
-choice /c:YN /n /m "[Y] Yes  [N] No"
+%SystemRoot%\System32\choice.exe /c:YN /n /m "[Y] Yes  [N] No"
 if %errorlevel% equ 1 (
 	shutdown /s /t 60 /c "A restart is required, we'll do that now" /f /d p:0:0
 	timeout 5
@@ -3538,9 +3549,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -3577,7 +3588,7 @@ echo.
 echo.
 echo                                                 %COL%[90m[ B for back ]         %COL%[31m[ X to close ]%COL%[37m
 echo.
-choice /c:1BX /n /m "%DEL%                                        Select a corresponding number to the options above >"
+%SystemRoot%\System32\choice.exe /c:1BX /n /m "%DEL%                                        Select a corresponding number to the options above >"
 set choice=%errorlevel%
 if "%choice%"=="1" goto Minecraft
 if "%choice%"=="2" goto MainMenu
@@ -3591,22 +3602,22 @@ echo.
 echo.
 echo.
 echo.
-echo.                                                                           %COL%[33m.  
-echo.                                                                        +N. 
-echo.                                                               //        oMMs 
-echo.                                                              +Nm`    ``yMMm- 
-echo.                                                           ``dMMsoyhh-hMMd.  
-echo.                                                           `yy/MMMMNh:dMMh`   
-echo.                                                          .hMM.sso++:oMMs`    
-echo.                                                         -mMMy:osyyys.No      
-echo.                                                        :NMMs-oo+/syy:-       
-echo.                                                       /NMN+ ``   :ys.        
-echo.                                                      `NMN:        +.         
-echo.                                                      om-                    
-echo.                                                       `.                                            
-echo. 
-echo. 
-echo. 
+echo.                                                                           %COL%[33m.
+echo.                                                                        +N.
+echo.                                                               //        oMMs
+echo.                                                              +Nm`    ``yMMm-
+echo.                                                           ``dMMsoyhh-hMMd.
+echo.                                                           `yy/MMMMNh:dMMh`
+echo.                                                          .hMM.sso++:oMMs`
+echo.                                                         -mMMy:osyyys.No
+echo.                                                        :NMMs-oo+/syy:-
+echo.                                                       /NMN+ ``   :ys.
+echo.                                                      `NMN:        +.
+echo.                                                      om-
+echo.                                                       `.
+echo.
+echo.
+echo.
 echo.
 echo.
 echo                                                      %COL%[1;4;34mSelect Minecraft Version%COL%[0m
@@ -3632,7 +3643,7 @@ echo.
 echo.
 echo                                                 %COL%[90m[ B for back ]         %COL%[31m[ X to close ]%COL%[37m
 echo.
-choice /c:123BX /n /m "%DEL%                                        Select a corresponding number to the options above >"
+%SystemRoot%\System32\choice.exe /c:123BX /n /m "%DEL%                                        Select a corresponding number to the options above >"
 set choice=%errorlevel%
 if %choice% equ 1 goto 1.7.10
 if %choice% equ 2 goto 1.8.9
@@ -3646,23 +3657,23 @@ echo.
 echo.
 echo.
 echo.
-echo.                                                                           %COL%[33m.  
-echo.                                                                        +N. 
-echo.                                                               //        oMMs 
-echo.                                                              +Nm`    ``yMMm- 
-echo.                                                           ``dMMsoyhh-hMMd.  
-echo.                                                           `yy/MMMMNh:dMMh`   
-echo.                                                          .hMM.sso++:oMMs`    
-echo.                                                         -mMMy:osyyys.No      
-echo.                                                        :NMMs-oo+/syy:-       
-echo.                                                       /NMN+ ``   :ys.        
-echo.                                                      `NMN:        +.         
-echo.                                                      om-                    
-echo.                                                       `.                                            
-echo. 
-echo. 
-echo. 
-echo. 
+echo.                                                                           %COL%[33m.
+echo.                                                                        +N.
+echo.                                                               //        oMMs
+echo.                                                              +Nm`    ``yMMm-
+echo.                                                           ``dMMsoyhh-hMMd.
+echo.                                                           `yy/MMMMNh:dMMh`
+echo.                                                          .hMM.sso++:oMMs`
+echo.                                                         -mMMy:osyyys.No
+echo.                                                        :NMMs-oo+/syy:-
+echo.                                                       /NMN+ ``   :ys.
+echo.                                                      `NMN:        +.
+echo.                                                      om-
+echo.                                                       `.
+echo.
+echo.
+echo.
+echo.
 echo.
 echo                                                   %COL%[37m Settings have been applied
 echo.
@@ -3671,7 +3682,7 @@ echo.
 echo.
 echo                                                          %COL%[90m[ B for back ]%COL%[37m
 echo.
-choice /c:B /n /m "%DEL%                                                               >:"
+%SystemRoot%\System32\choice.exe /c:B /n /m "%DEL%                                                               >:"
 goto GameSettings
 
 :1.7.10
@@ -3900,27 +3911,86 @@ goto MinecraftConfirmation
 
 goto MainMenu
 
+:dog
+cls
+echo.
+echo.
+echo.
+echo.
+echo.
+echo.
+echo             @@@    @@@@@@@@@@@@@@   @@@
+echo         %@@@   @@@@              @@@   @@@@
+echo         %@@@   @@@@              @@@   @@@@
+echo         %@@@                           @@@@
+echo         %@@@                               @@@                     @@@
+echo      @@@,      @@@@       @@@                 @@@@              @@@   @@@@
+echo      @@@,      @@@@       @@@                 @@@@              @@@   @@@@
+echo      @@@,                                         @@@@@@@       @@@   @@@@
+echo      @@@,          @@@@@@@                               @@@@@@@@@@   @@@@
+echo      @@@,          @@@@@@@                               @@@@@@@@@@   @@@@
+echo      @@@,   @@@    @@@       @@@@                                     @@@@
+echo      @@@,      @@@@@@@@@@@@@@                                         @@@@
+echo      @@@,                                                             @@@@
+echo      @@@,                                                             @@@@
+echo      @@@,                                                             @@@@
+echo      @@@,                                                             @@@@
+echo      @@@,                                                             @@@@
+echo      @@@,                                                             @@@@
+echo      @@@,                                                          @@@
+echo         %@@@                                                       @@@
+echo         %@@@                                                       @@@
+echo         %@@@       @@@@@@@       @@@@@@@@@@@@@       @@@@@@@       @@@
+echo         %@@@       @@@@@@@       @@@       @@@       @@@@@@@       @@@
+echo         %@@@   @@@@   @@@@   @@@@          @@@    @@@    @@@    @@@
+echo         %@@@   @@@@   @@@@   @@@@          @@@    @@@    @@@    @@@
+echo             @@@           @@@                 @@@@          @@@@
+echo					      hi
+echo.
+echo.
+echo                  		  X to close
+echo.
+%SystemRoot%\System32\choice.exe /c:XD /n /m "%DEL%
+set choice=%errorlevel%
+if "%choice%"=="1" exit /b
+if "%choice%"=="2" goto Dog2
+goto dog
+
+:dog2
+cls
+echo So you want more dog?
+timeout /t 3 >nul 2>&1
+cls
+echo I don't have more dogs for you sorry
+timeout /t 3 >nul 2>&1
+cls
+echo Maybe come back at another time? I'll get some for ya
+timeout /t 3 >nul 2>&1
+cls
+echo bye
+timeout /t 2  >nul 2>&1
+exit /b
 :More
 cls
 echo.
 echo.
 echo.
 echo.
-echo.                                                                           %COL%[33m.  
-echo.                                                                          +N. 
-echo.                                                               //        oMMs 
-echo.                                                              +Nm`    ``yMMm- 
-echo.                                                           ``dMMsoyhh-hMMd.  
-echo.                                                           `yy/MMMMNh:dMMh`   
-echo.                                                          .hMM.sso++:oMMs`    
-echo.                                                         -mMMy:osyyys.No      
-echo.                                                        :NMMs-oo+/syy:-       
-echo.                                                       /NMN+ ``   :ys.        
-echo.                                                      `NMN:        +.         
-echo.                                                      om-                    
-echo.                                                       `.                                            
-echo. 
-echo. 
+echo.                                                                           %COL%[33m.
+echo.                                                                          +N.
+echo.                                                               //        oMMs
+echo.                                                              +Nm`    ``yMMm-
+echo.                                                           ``dMMsoyhh-hMMd.
+echo.                                                           `yy/MMMMNh:dMMh`
+echo.                                                          .hMM.sso++:oMMs`
+echo.                                                         -mMMy:osyyys.No
+echo.                                                        :NMMs-oo+/syy:-
+echo.                                                       /NMN+ ``   :ys.
+echo.                                                      `NMN:        +.
+echo.                                                      om-
+echo.                                                       `.
+echo.
+echo.
 echo.
 echo                  %COL%[33m[ %COL%[37m1 %COL%[33m] %COL%[37mAbout                                                   %COL%[33m[ %COL%[37m2 %COL%[33m] %COL%[37mDisclaimer
 echo.
@@ -3944,7 +4014,7 @@ echo.
 echo.
 echo                                                 %COL%[90m[ B for back ]         %COL%[31m[ X to close ]%COL%[37m
 echo.
-choice /c:12345BX /n /m "%DEL%                                        Select a corresponding number to the options above >"
+%SystemRoot%\System32\choice.exe /c:12345BX /n /m "%DEL%                                        Select a corresponding number to the options above >"
 set choice=%errorlevel%
 if "%choice%"=="1" goto About
 if "%choice%"=="2" goto ViewDisclaimer
@@ -3965,7 +4035,7 @@ call :ColorText 8 "                                                      [ press
 echo.
 echo.
 echo.
-choice /c:X /n /m "%DEL%                                                               >:"
+%SystemRoot%\System32\choice.exe /c:X /n /m "%DEL%                                                               >:"
 set choice=%errorlevel%
 if "%choice%"=="1" goto More
 
@@ -3974,9 +4044,9 @@ cls
 echo.
 echo.
 echo.                                      %COL%[33m+N.
-echo.                           //        oMMs         
-echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    :::::::::: 
-echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:  
+echo.                           //        oMMs
+echo.                          +Nm`    ``yMMm-     ::::::::     ::::    :::    ::::::::::
+echo.                       ``dMMsoyhh-hMMd.     :+:    :+:    :+:+:   :+:    :+:
 echo.                       `yy/MMMMNh:dMMh`    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                      .hMM.sso++:oMMs`    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                     -mMMy:osyyys.No     +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -3994,7 +4064,7 @@ echo.
 echo %COL%[91m  WARNING:
 echo %COL%[37m  Please note that we cannot guarantee an FPS boost from applying our optimizations, every system + configuration is different.
 echo.
-echo     %COL%[33m1.%COL%[37m Everything is "use at your own risk", we are %COL%[91mNOT LIABLE%COL%[37m if you damage your system in any way 
+echo     %COL%[33m1.%COL%[37m Everything is "use at your own risk", we are %COL%[91mNOT LIABLE%COL%[37m if you damage your system in any way
 echo        (ex. not following the disclaimers carefully).
 echo.
 echo     %COL%[33m2.%COL%[37m If you don't know what a tweak is, do not use it and contact our support team to receive more assistance.
@@ -4003,13 +4073,13 @@ echo     %COL%[33m3.%COL%[37m Even though we have an automatic restore point fea
 echo.
 echo   For any questions and/or concerns, please join our discord: discord.gg/hone
 echo.
-echo   Please enter "I agree" without quotes to continue: 
+echo   Please enter "I agree" without quotes to continue:
 echo.
 echo.
 echo.
 echo                                                         [ press X to go back ]
 echo.
-choice /c:X /n /m "%DEL%                                                                 >:"
+%SystemRoot%\System32\choice.exe /c:X /n /m "%DEL%                                                                 >:"
 set choice=%errorlevel%
 if "%choice%"=="1" goto More
 
@@ -4058,7 +4128,7 @@ echo.
 echo.
 call :ColorText 8 "                                                     [ press B to go back ]"
 echo.
-choice /c:B /n /m "%DEL%                                                               >:"
+%SystemRoot%\System32\choice.exe /c:B /n /m "%DEL%                                                               >:"
 set choice=%errorlevel%
 if "%choice%"=="1" goto More
 
@@ -4122,7 +4192,7 @@ for %%F in ("%file%") do Reg query "HKCU\Software\Microsoft\Windows NT\CurrentVe
 	echo CPU High Class
 ) >nul 2>&1
 echo.
-choice /c:"CQ" /n /m "%BS%               [C] Continue  [Q] Quit" & if !errorlevel! equ 2 exit /b
+%SystemRoot%\System32\choice.exe /c:"CQ" /n /m "%BS%               [C] Continue  [Q] Quit" & if !errorlevel! equ 2 exit /b
 goto:eof
 
 :softRestart
@@ -4179,14 +4249,14 @@ echo.
 echo.
 echo                             [X] Close
 echo.
-choice /c:X /n /m "%DEL%                                >:"
+%SystemRoot%\System32\choice.exe /c:X /n /m "%DEL%                                >:"
 Mode 130,45
 goto:eof
 
 
 
-echo       :::    :::     ::::::::     ::::    :::    ::::::::::     
-echo      :+:    :+:    :+:    :+:    :+:+:   :+:    :+:            
+echo       :::    :::     ::::::::     ::::    :::    ::::::::::
+echo      :+:    :+:    :+:    :+:    :+:+:   :+:    :+:
 echo     +:+    +:+    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo    +#++:++#++    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo   +#+    +#+    +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -4196,8 +4266,8 @@ echo                                                                     ###    
 echo                                                             ##     ###    ##     ###
 echo                                                              ########      ########
 
-echo       :::    :::     ::::::::     ::::    :::    ::::::::::     
-echo      :+:    :+:    :+:    :+:    :+:+:   :+:    :+:            
+echo       :::    :::     ::::::::     ::::    :::    ::::::::::
+echo      :+:    :+:    :+:    :+:    :+:+:   :+:    :+:
 echo     +:+    +:+    +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo    +#++:++#++    +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo   +#+    +#+    +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -4208,9 +4278,9 @@ echo                                                             ##     ###    #
 echo                                                              ########      ########
 
 echo.                                          %COL%[33m+N.
-echo.                               //        oMMs         
-echo.                              +Nm`    ``yMMm-      ::::::::     ::::    :::    :::::::::: 
-echo.                           ``dMMsoyhh-hMMd.      :+:    :+:    :+:+:   :+:    :+:  
+echo.                               //        oMMs
+echo.                              +Nm`    ``yMMm-      ::::::::     ::::    :::    ::::::::::
+echo.                           ``dMMsoyhh-hMMd.      :+:    :+:    :+:+:   :+:    :+:
 echo.                           `yy/MMMMNh:dMMh`     +:+    +:+    :+:+:+  +:+    +:+                 +::+:+::      +::+:+::
 echo.                          .hMM.sso++:oMMs`     +#+    +:+    +#+ +:+ +#+    +#++:++#           ++:    #++    ++:    #++
 echo.                         -mMMy:osyyys.No      +#+    +#+    +#+  +#+#+#    +#+                +#+    +#+    +#+    +#+
@@ -4221,23 +4291,23 @@ echo.                      om-                                                  
 echo.                       `.                                                                  ########      ########
 
 echo.                                          %COL%[33m+N.
-echo.                               //        oMMs         
-echo.                              +Nm`    ``yMMm-               :::    :::     ::::::::     ::::    :::    :::::::::: 
-echo.                           ``dMMsoyhh-hMMd.                :+:    :+:    :+:    :+:    :+:+:   :+:    :+:  
-echo.                           `yy/MMMMNh:dMMh`               +:+    +:+    +:+    +:+    :+:+:+  +:+    +:+    
-echo.                          .hMM.sso++:oMMs`               +#++:++#++    +#+    +:+    +#+ +:+ +#+    +#++:++#    
-echo.                         -mMMy:osyyys.No                +#+    +#+    +#+    +#+    +#+  +#+#+#    +#+   
-echo.                        :NMMs-oo+/syy:-                #+#    #+#    #+#    #+#    #+#   #+#+#    #+#   
+echo.                               //        oMMs
+echo.                              +Nm`    ``yMMm-               :::    :::     ::::::::     ::::    :::    ::::::::::
+echo.                           ``dMMsoyhh-hMMd.                :+:    :+:    :+:    :+:    :+:+:   :+:    :+:
+echo.                           `yy/MMMMNh:dMMh`               +:+    +:+    +:+    +:+    :+:+:+  +:+    +:+
+echo.                          .hMM.sso++:oMMs`               +#++:++#++    +#+    +:+    +#+ +:+ +#+    +#++:++#
+echo.                         -mMMy:osyyys.No                +#+    +#+    +#+    +#+    +#+  +#+#+#    +#+
+echo.                        :NMMs-oo+/syy:-                #+#    #+#    #+#    #+#    #+#   #+#+#    #+#
 echo.                       /NMN+ ``   :ys.                ###    ###     ########     ###    ####    ##########
-echo.                      `NMN:        +.                
-echo.                      om-                            
-echo.                       `.                            
+echo.                      `NMN:        +.
+echo.                      om-
+echo.                       `.
 
 :ColorText
 echo off
 <nul set /p ".=%DEL%" > "%~2"
 findstr /v /a:%1 /R "^$" "%~2" nul
-del "%~2" > nul  
+del "%~2" > nul
 goto :eof
 
 :HoneCtrlError
@@ -4258,7 +4328,7 @@ echo. ^& ^
 echo. ^& ^
 echo      [X] Close ^& ^
 echo. ^& ^
-choice /c:X /n /m "%DEL%                                >:" ^& ^
+%SystemRoot%\System32\choice.exe /c:X /n /m "%DEL%                                >:" ^& ^
 exit /b
 goto:eof
 
@@ -4282,7 +4352,7 @@ echo. ^& ^
 echo      [Y] Yes ^& ^
 echo      [N] No ^& ^
 echo. ^& ^
-choice /c:YNX /n /m "%DEL%                                >:" ^& ^
+%SystemRoot%\System32\choice.exe /c:YNX /n /m "%DEL%                                >:" ^& ^
 if !errorlevel! equ 1 ( ^
 	shutdown /s /t 60 /c "A restart is required, we'll do that now" /f /d p:0:0 ^& ^
 	timeout 5 ^& ^


### PR DESCRIPTION
i found some issues that i could fix in your obs, ffmpeg and blur settings, mostly encoding related stuff.
notable changes:
 - added automatic monitor res detection for obs settings instead of assuming 1920x1080
 - replaced ffmpeg installation with one that downloads the latest essentials build from https://www.gyan.dev/ffmpeg/
 - general improvements in all encoding settings
 - added warning for interpolating low-fps minecraft footage (looks bad 99% of the time)
 - slight modifications in all blur configs to remove redundant settings, nothing major
 - changed all occurrences of `%SystemDrive\users\%username%` to `%userprofile%` (built-in env variable that expands to the same thing, more concise and safe)