### PR TITLE
Change .blurconfig(s)

### DIFF
--- a/Files/Minecraft/240-360/Amd/Minecraft240Amd.cfg
+++ b/Files/Minecraft/240-360/Amd/Minecraft240Amd.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 1.6
+blur amount: 1.5
 blur output fps: 60
-blur weighting: gaussian_sym
+blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 1200
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -27,12 +27,12 @@ contrast: 1
 gpu: true
 gpu type (nvidia/amd/intel): amd
 deduplicate: true
-custom ffmpeg filters: 
+custom ffmpeg filters: -c:v h264_amf -quality quality -qp_i 12 -qp_p 12 -qp_b 12
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
-blur weighting bound: [0,1]
+blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp

--- a/Files/Minecraft/240-360/Intel/Minecraft240Intel.cfg
+++ b/Files/Minecraft/240-360/Intel/Minecraft240Intel.cfg
@@ -36,6 +36,6 @@ blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp
-interpolation speed: faster
+interpolation speed: medium
 interpolation tuning: weak
 interpolation algorithm: 13

--- a/Files/Minecraft/240-360/Intel/Minecraft240Intel.cfg
+++ b/Files/Minecraft/240-360/Intel/Minecraft240Intel.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 1.6
+blur amount: 1.5
 blur output fps: 60
-blur weighting: gaussian_sym
+blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 1200
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -27,15 +27,15 @@ contrast: 1
 gpu: true
 gpu type (nvidia/amd/intel): intel
 deduplicate: true
-custom ffmpeg filters: 
+custom ffmpeg filters: -c:v libx264 -preset medium -crf 15 -c:a copy
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
-blur weighting bound: [0,1]
+blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp
-interpolation speed: medium
+interpolation speed: faster
 interpolation tuning: weak
 interpolation algorithm: 13

--- a/Files/Minecraft/240-360/Nvidia/Minecraft240Nvidia.cfg
+++ b/Files/Minecraft/240-360/Nvidia/Minecraft240Nvidia.cfg
@@ -36,6 +36,6 @@ blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp
-interpolation speed: faster
+interpolation speed: medium
 interpolation tuning: weak
 interpolation algorithm: 13

--- a/Files/Minecraft/240-360/Nvidia/Minecraft240Nvidia.cfg
+++ b/Files/Minecraft/240-360/Nvidia/Minecraft240Nvidia.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 1.6
+blur amount: 1.5
 blur output fps: 60
-blur weighting: gaussian_sym
+blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 1200
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -27,15 +27,15 @@ contrast: 1
 gpu: true
 gpu type (nvidia/amd/intel): nvidia
 deduplicate: true
-custom ffmpeg filters: 
+custom ffmpeg filters: -c:v h264_nvenc -rc constqp -preset p7 -qp 15
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
-blur weighting bound: [0,1]
+blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp
-interpolation speed: medium
+interpolation speed: faster
 interpolation tuning: weak
 interpolation algorithm: 13

--- a/Files/Minecraft/480+/Amd/Minecraft480Amd.cfg
+++ b/Files/Minecraft/480+/Amd/Minecraft480Amd.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 2.22
+blur amount: 1.5
 blur output fps: 60
-blur weighting: gaussian_sym
+blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 2400
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -26,11 +26,11 @@ contrast: 1
 - advanced rendering
 gpu: true
 gpu type (nvidia/amd/intel): amd
-deduplicate: false
-custom ffmpeg filters: 
+deduplicate: true
+custom ffmpeg filters: -c:v h264_amf -quality quality -qp_i 12 -qp_p 12 -qp_b 12
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
 blur weighting bound: [0,2]
 
@@ -38,4 +38,4 @@ blur weighting bound: [0,2]
 interpolation program (svp/rife/rife-ncnn): svp
 interpolation speed: faster
 interpolation tuning: weak
-interpolation algorithm: 2
+interpolation algorithm: 13

--- a/Files/Minecraft/480+/Intel/Minecraft480Intel.cfg
+++ b/Files/Minecraft/480+/Intel/Minecraft480Intel.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 2.22
+blur amount: 1.5
 blur output fps: 60
-blur weighting: gaussian_sym
+blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 2400
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -26,11 +26,11 @@ contrast: 1
 - advanced rendering
 gpu: true
 gpu type (nvidia/amd/intel): intel
-deduplicate: false
-custom ffmpeg filters: 
+deduplicate: true
+custom ffmpeg filters: -c:v libx264 -preset medium -crf 15 -c:a copy
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
 blur weighting bound: [0,2]
 
@@ -38,4 +38,4 @@ blur weighting bound: [0,2]
 interpolation program (svp/rife/rife-ncnn): svp
 interpolation speed: faster
 interpolation tuning: weak
-interpolation algorithm: 2
+interpolation algorithm: 13

--- a/Files/Minecraft/480+/Nvidia/Minecraft480Nvidia.cfg
+++ b/Files/Minecraft/480+/Nvidia/Minecraft480Nvidia.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 2.22
+blur amount: 1.5
 blur output fps: 60
-blur weighting: gaussian_sym
+blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 2400
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -25,12 +25,12 @@ contrast: 1
 
 - advanced rendering
 gpu: true
-gpu type (nvidia/amd/intel): nvidia
-deduplicate: false
-custom ffmpeg filters: 
+gpu type (nvidia/amd/intel): intel
+deduplicate: true
+custom ffmpeg filters: -c:v h264_nvenc -rc constqp -preset p7 -qp 15
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
 blur weighting bound: [0,2]
 
@@ -38,4 +38,4 @@ blur weighting bound: [0,2]
 interpolation program (svp/rife/rife-ncnn): svp
 interpolation speed: faster
 interpolation tuning: weak
-interpolation algorithm: 2
+interpolation algorithm: 13

--- a/Files/Minecraft/480+/Nvidia/Minecraft480Nvidia.cfg
+++ b/Files/Minecraft/480+/Nvidia/Minecraft480Nvidia.cfg
@@ -25,7 +25,7 @@ contrast: 1
 
 - advanced rendering
 gpu: true
-gpu type (nvidia/amd/intel): intel
+gpu type (nvidia/amd/intel): nvidia
 deduplicate: true
 custom ffmpeg filters: -c:v h264_nvenc -rc constqp -preset p7 -qp 15
 

--- a/Files/Minecraft/Any/Amd/MinecraftAnyAmd.cfg
+++ b/Files/Minecraft/Any/Amd/MinecraftAnyAmd.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 1.1
-blur output fps: 30
+blur amount: 1.5
+blur output fps: 60
 blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 840
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -27,15 +27,15 @@ contrast: 1
 gpu: true
 gpu type (nvidia/amd/intel): amd
 deduplicate: true
-custom ffmpeg filters: 
+custom ffmpeg filters: -c:v h264_amf -quality quality -qp_i 12 -qp_p 12 -qp_b 12
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
-blur weighting bound: [0,1,1,1,1,0]
+blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp
 interpolation speed: medium
 interpolation tuning: weak
-interpolation algorithm: 23
+interpolation algorithm: 13

--- a/Files/Minecraft/Any/Intel/MinecraftAnyIntel.cfg
+++ b/Files/Minecraft/Any/Intel/MinecraftAnyIntel.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 1.1
-blur output fps: 30
+blur amount: 1.5
+blur output fps: 60
 blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 840
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -27,15 +27,15 @@ contrast: 1
 gpu: true
 gpu type (nvidia/amd/intel): intel
 deduplicate: true
-custom ffmpeg filters: 
+custom ffmpeg filters: -c:v libx264 -preset medium -crf 15 -c:a copy
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
-blur weighting bound: [0,1,1,1,1,0]
+blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp
 interpolation speed: medium
 interpolation tuning: weak
-interpolation algorithm: 23
+interpolation algorithm: 13

--- a/Files/Minecraft/Any/Nvidia/MinecraftAnyNvidia.cfg
+++ b/Files/Minecraft/Any/Nvidia/MinecraftAnyNvidia.cfg
@@ -1,17 +1,17 @@
 - blur
 blur: true
-blur amount: 1.1
-blur output fps: 30
+blur amount: 1.5
+blur output fps: 60
 blur weighting: equal
 
 - interpolation
 interpolate: true
-interpolated fps: 1920
+interpolated fps: 840
 
 - rendering
-quality: 15
-preview: true
-detailed filenames: false
+quality: 18
+preview: false
+detailed filenames: true
 
 - timescale
 input timescale: 1
@@ -27,15 +27,15 @@ contrast: 1
 gpu: true
 gpu type (nvidia/amd/intel): nvidia
 deduplicate: true
-custom ffmpeg filters: 
+custom ffmpeg filters: -c:v h264_nvenc -rc constqp -preset p7 -qp 15
 
 - advanced blur
-blur weighting gaussian std dev: 1
+blur weighting gaussian std dev: 2
 blur weighting triangle reverse: false
-blur weighting bound: [0,1,1,1,1,0]
+blur weighting bound: [0,2]
 
 - advanced interpolation
 interpolation program (svp/rife/rife-ncnn): svp
 interpolation speed: medium
 interpolation tuning: weak
-interpolation algorithm: 23
+interpolation algorithm: 13


### PR DESCRIPTION
The changes I have made make the configs more general, as before there were some that were 2.2 blur amount on 60 fps which is way to much in my opinon, as well as a 30 FPS output config even though it wasnt labeled as 30 out.

Instead of having all these different folders and files, you could have one master config that the user can change using inputs in the batch file, so then they can input the exact FPS they are recording in and what output FPS they want.

I may end up adding this 'input' in the batch file, but for now, im just changing the configs.